### PR TITLE
Check videojs variable before accessing it

### DIFF
--- a/src/tracker.js
+++ b/src/tracker.js
@@ -69,7 +69,7 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   }
 
   getPlayerVersion () {
-    return videojs.VERSION
+    return typeof videojs !== 'undefined' && videojs.VERSION
   }
 
   isMuted () {


### PR DESCRIPTION
When videojs variable is not defined, avoid breaking the tracker.