### PR TITLE
NR-338890-New Relic VideoJS tracker is throwing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## [0.7.1] - 2014/11/13
-### Fix
+### Bug fix
 - Add aditional checks to `player`.
 
 ## [0.7.0] - 2024/09/18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.7.1] - 2014/11/13
+### Fix
+- Add aditional checks to `player`.
+
 ## [0.7.0] - 2024/09/18
 ### Add
 - Language attribute.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newrelic-video-videojs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newrelic-video-videojs",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "newrelic-video-core": "github:newrelic/video-core-js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-video-videojs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "New relic tracker for Videojs",
   "main": "src/index.js",
   "scripts": {

--- a/src/ads/brightcove-ima.js
+++ b/src/ads/brightcove-ima.js
@@ -15,7 +15,7 @@ export default class BrightcoveImaAdsTracker extends VideojsAdsTracker {
   }
 
   getPlayhead () {
-    return this.player.ima3.adPlayer.currentTime()
+    return this.player?.ima3?.adPlayer?.currentTime()
   }
 
   registerListeners () {


### PR DESCRIPTION
While running ads on live video streams, we encountered the following error: VIDEOJS: ERROR: TypeError: Cannot read property 'currentTime' of undefined.

We have implemented optional chaining to check for null value

Jira Link - https://new-relic.atlassian.net/browse/NR-338890