### PR TITLE
fix: Update bitrate calculation to use measured throughput

### DIFF
--- a/src/techs/contrib-hls.js
+++ b/src/techs/contrib-hls.js
@@ -1,6 +1,7 @@
 export default class ContribHlsTech {
   constructor (tech) {
     this.tech = tech.vhs
+    this.player = tech.el().player // Store player reference for playback bitrate calculation
   }
 
   getRenditionName () {
@@ -34,6 +35,43 @@ export default class ContribHlsTech {
       var media = this.tech.playlists.media()
       if (media && media.attributes && media.attributes.RESOLUTION) {
         return media.attributes.RESOLUTION.height
+      }
+    } catch (err) { }
+    return null
+  }
+
+  getBitrate () {
+    // Calculate playback bitrate (actual content consumption rate)
+    return this.getContentBitratePlayback()
+  }
+
+  getContentBitratePlayback () {
+    try {
+      // VHS provides stats for calculating actual playback bitrate
+      if (this.tech.stats && this.player) {
+        const stats = this.tech.stats
+
+        // Calculate actual playback bitrate based on content consumption
+        if (stats.mediaBytesTransferred > 0 && stats.mediaRequests > 0) {
+          const currentTime = this.player.currentTime() // in seconds
+          const playbackRate = this.player.playbackRate() || 1
+
+          // Adjust playback time by playback rate
+          const effectivePlaybackTime = currentTime / playbackRate
+
+          if (effectivePlaybackTime > 0) {
+            const bitsTransferred = stats.mediaBytesTransferred * 8
+            return bitsTransferred / effectivePlaybackTime
+          }
+        }
+      }
+
+      // Fallback to VHS bandwidth estimates if stats not available
+      if (this.tech.bandwidth !== undefined && this.tech.bandwidth > 0) {
+        return this.tech.bandwidth
+      }
+      if (this.tech.systemBandwidth !== undefined && this.tech.systemBandwidth > 0) {
+        return this.tech.systemBandwidth
       }
     } catch (err) { }
     return null

--- a/src/techs/hls-js.js
+++ b/src/techs/hls-js.js
@@ -1,45 +1,71 @@
 export default class HlsJs {
-  constructor (tech) {
-    this.tech = tech.vhs_
+  constructor(tech) {
+    this.tech = tech.vhs_;
+    this.player = tech.el().player; // Store player reference for currentTime
   }
 
-  getResource (tech) {
-    return this.tech.url
+  getResource(tech) {
+    return this.tech.url;
   }
 
-  getRenditionName (tech) {
+  getRenditionName(tech) {
     try {
-      var level = this.tech.levels[this.tech.currentLevel]
-      if (level && level.name) return level.name
-    } catch (err) { }
-    return null
+      var level = this.tech.levels[this.tech.currentLevel];
+      if (level && level.name) return level.name;
+    } catch (err) {}
+    return null;
   }
 
-  getRenditionBitrate (tech) {
+  getRenditionBitrate(tech) {
     try {
-      var level = this.tech.levels[this.tech.currentLevel]
-      if (level && level.bitrate) return level.bitrate
-    } catch (err) { }
-    return null
+      var level = this.tech.levels[this.tech.currentLevel];
+      if (level && level.bitrate) return level.bitrate;
+    } catch (err) {}
+    return null;
   }
 
-  getRenditionWidth (tech) {
+  getRenditionWidth(tech) {
     try {
-      var level = this.tech.levels[this.tech.currentLevel]
-      if (level && level.width) return level.width
-    } catch (err) { }
-    return null
+      var level = this.tech.levels[this.tech.currentLevel];
+      if (level && level.width) return level.width;
+    } catch (err) {}
+    return null;
   }
 
-  getRenditionHeight (tech) {
+  getRenditionHeight(tech) {
     try {
-      var level = this.tech.levels[this.tech.currentLevel]
-      if (level && level.height) return level.height
-    } catch (err) { }
-    return null
+      var level = this.tech.levels[this.tech.currentLevel];
+      if (level && level.height) return level.height;
+    } catch (err) {}
+    return null;
+  }
+
+  getBitrate() {
+    // Default uses playback bitrate (Method 4)
+    return this.getContentBitratePlayback();
+  }
+
+  getContentBitratePlayback() {
+    try {
+      if (this.tech.stats && this.player) {
+        const stats = this.tech.stats;
+        // Calculate actual playback bitrate based on content consumption
+        if (stats.mediaBytesTransferred > 0 && stats.mediaRequests > 0) {
+          const currentTime = this.player.currentTime(); // in seconds
+          const playbackRate = this.player.playbackRate() || 1;
+          const effectivePlaybackTime = currentTime / playbackRate;
+
+          if (effectivePlaybackTime > 0) {
+            const bitsTransferred = stats.mediaBytesTransferred * 8;
+            return bitsTransferred / effectivePlaybackTime;
+          }
+        }
+      }
+    } catch (err) {}
+    return null;
   }
 }
 
 HlsJs.isUsing = function (tech) {
-  return !!tech.vhs_
-}
+  return !!tech.vhs_;
+};

--- a/src/techs/shaka.js
+++ b/src/techs/shaka.js
@@ -1,49 +1,74 @@
 export default class ShakaTech {
-  constructor (tech) {
-    this.tech = tech.shakaPlayer
+  constructor(tech) {
+    this.tech = tech.shakaPlayer;
+    this.player = tech.el().player; // Store player reference for playback bitrate calculation
   }
 
-  getSrc (tech) {
+  getSrc(tech) {
     try {
-      return this.tech.getManifestUri()
+      return this.tech.getManifestUri();
     } catch (err) {}
-    return null
+    return null;
   }
 
-  getRenditionBitrate (tech) {
+  getRenditionBitrate(tech) {
     try {
-      return this.tech.getStats().streamBandwidth
-    } catch (err) { }
-    return null
+      return this.tech.getStats().streamBandwidth;
+    } catch (err) {}
+    return null;
   }
 
-  getRenditionWidth (tech) {
+  getRenditionWidth(tech) {
     try {
-      var tracks = this.tech.getVariantTracks()
+      var tracks = this.tech.getVariantTracks();
       for (var i in tracks) {
-        var track = tracks[i]
+        var track = tracks[i];
         if (track.active && track.type === 'video') {
-          return track.width
+          return track.width;
         }
       }
-    } catch (err) { }
-    return null
+    } catch (err) {}
+    return null;
   }
 
-  getRenditionHeight (tech) {
+  getRenditionHeight(tech) {
     try {
-      var tracks = this.tech.getVariantTracks()
+      var tracks = this.tech.getVariantTracks();
       for (var i in tracks) {
-        var track = tracks[i]
+        var track = tracks[i];
         if (track.active && track.type === 'video') {
-          return track.height
+          return track.height;
         }
       }
-    } catch (err) { }
-    return null
+    } catch (err) {}
+    return null;
+  }
+
+  getBitrate() {
+    // Calculate playback bitrate (actual content consumption rate)
+    return this.getContentBitratePlayback();
+  }
+
+  getContentBitratePlayback() {
+    try {
+      var stats = this.tech.getStats();
+      if (stats) {
+        // Shaka's estimatedBandwidth is the actual measured network bandwidth
+        // This is the closest equivalent to playback bitrate calculation
+        if (stats.estimatedBandwidth && stats.estimatedBandwidth > 0) {
+          return stats.estimatedBandwidth;
+        }
+
+        // Fallback to streamBandwidth (bitrate of current variant from manifest)
+        if (stats.streamBandwidth && stats.streamBandwidth > 0) {
+          return stats.streamBandwidth;
+        }
+      }
+    } catch (err) {}
+    return null;
   }
 }
 
 ShakaTech.isUsing = function (tech) {
-  return !!tech.shakaPlayer
-}
+  return !!tech.shakaPlayer;
+};

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -112,158 +112,40 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   }
 
   getBitrate() {
-    let videoBitrate = 0;
-    let audioBitrate = 0;
-    let totalBitrate = 0;
+    return this.getContentBitratePlayback();
+  }
 
-    if (this.player) {
-      const tech = this.player.tech({ IWillNotUseThisInPlugins: true });
+  // Measures: Actual content consumption rate during playback
+  getContentBitratePlayback() {
+    const tech = this.player.tech({ IWillNotUseThisInPlugins: true });
 
-      if (tech) {
-        let playlists, currentMedia;
+    // VHS/HLS support - calculate actual playback bitrate
+    if (tech?.vhs?.stats) {
+      const stats = tech.vhs.stats;
 
-        // Method 1: Try VHS (Video HTTP Streaming) - most common for HLS/DASH
-        if (tech.vhs && tech.vhs.playlists && tech.vhs.playlists.media) {
-          playlists = tech.vhs.playlists;
-          currentMedia = tech.vhs.playlists.media();
-        } else if (tech.hls && tech.hls.playlists && tech.hls.playlists.media) {
-          playlists = tech.hls.playlists;
-          currentMedia = tech.hls.playlists.media();
+      // Calculate actual playback bitrate based on content consumption
+      // This represents the bitrate at which content is being played back
+      if (stats.mediaBytesTransferred > 0 && stats.mediaRequests > 0) {
+        // Get total playback time (accounting for playback rate)
+        const currentTime = this.player.currentTime(); // in seconds
+        const playbackRate = this.player.playbackRate() || 1;
+
+        // Adjust playback time by playback rate
+        // If playing at 2x speed, you consume 2x the bitrate
+        const effectivePlaybackTime = currentTime / playbackRate;
+
+        if (effectivePlaybackTime > 0) {
+          const bitsTransferred = stats.mediaBytesTransferred * 8;
+          const playbackBitrate = bitsTransferred / effectivePlaybackTime;
+          return playbackBitrate;
         }
-
-        if (currentMedia && currentMedia.attributes) {
-          if (currentMedia.attributes.BANDWIDTH) {
-            videoBitrate = currentMedia.attributes.BANDWIDTH;
-          }
-
-          // Get audio bitrate if available
-          const audioTracks = this.player.audioTracks();
-          let activeAudioTrack;
-
-          if (audioTracks && audioTracks.length > 0) {
-            for (let i = 0; i < audioTracks.length; i++) {
-              if (audioTracks[i].enabled) {
-                activeAudioTrack = audioTracks[i];
-                break;
-              }
-            }
-          }
-
-          if (activeAudioTrack && currentMedia.attributes.AUDIO) {
-            let masterPlaylist;
-            if (playlists) {
-              masterPlaylist = playlists.master || playlists.main;
-            }
-
-            if (
-              masterPlaylist &&
-              masterPlaylist.mediaGroups &&
-              masterPlaylist.mediaGroups.AUDIO
-            ) {
-              const audioGroup =
-                masterPlaylist.mediaGroups.AUDIO[currentMedia.attributes.AUDIO];
-              const audioMediaInfo =
-                audioGroup && audioGroup[activeAudioTrack.id];
-
-              if (
-                audioMediaInfo &&
-                audioMediaInfo.playlists &&
-                audioMediaInfo.playlists[0]
-              ) {
-                const audioPlaylist = audioMediaInfo.playlists[0].attributes;
-                if (audioPlaylist && audioPlaylist.BANDWIDTH) {
-                  audioBitrate = audioPlaylist.BANDWIDTH;
-                }
-              }
-            }
-          }
-
-          totalBitrate = videoBitrate + audioBitrate;
-
-          return totalBitrate; // Return in bps
-        }
-
-        // Method 2: Try Shaka Player
-        const shakaPlayer =
-          tech.shakaPlayer_ || tech.shaka_ || tech.shakaPlayer;
-        if (shakaPlayer && typeof shakaPlayer.getStats === 'function') {
-          const stats = shakaPlayer.getStats();
-          if (stats && stats.streamBandwidth) {
-            return stats.streamBandwidth;
-          }
-        }
-
-        // Method 3: Try HLS.js
-        const hlsJs = tech.hls_;
-        if (hlsJs && hlsJs.levels && hlsJs.currentLevel >= 0) {
-          const currentLevel = hlsJs.levels[hlsJs.currentLevel];
-          if (currentLevel && currentLevel.bitrate) {
-            return currentLevel.bitrate;
-          }
-        }
-      }
-
-      // Method 4: Try DASH.js
-      let dashPlayer;
-      if (this.player.mediaPlayer) {
-        dashPlayer = this.player.mediaPlayer;
-      } else if (this.player.dash && this.player.dash.mediaPlayer) {
-        dashPlayer = this.player.dash.mediaPlayer;
-      }
-
-      if (
-        dashPlayer &&
-        typeof dashPlayer.getQualityFor === 'function' &&
-        typeof dashPlayer.getBitrateInfoListFor === 'function'
-      ) {
-        // Get audio bitrate
-        const audioQuality = dashPlayer.getQualityFor('audio');
-        const audioBitrateList = dashPlayer.getBitrateInfoListFor('audio');
-        if (
-          audioQuality !== undefined &&
-          audioBitrateList &&
-          audioBitrateList[audioQuality] &&
-          audioBitrateList[audioQuality].bitrate
-        ) {
-          audioBitrate = audioBitrateList[audioQuality].bitrate;
-        }
-
-        // Get video bitrate
-        const videoQuality = dashPlayer.getQualityFor('video');
-        const videoBitrateList = dashPlayer.getBitrateInfoListFor('video');
-        if (
-          videoQuality !== undefined &&
-          videoBitrateList &&
-          videoBitrateList[videoQuality] &&
-          videoBitrateList[videoQuality].bitrate
-        ) {
-          videoBitrate = videoBitrateList[videoQuality].bitrate;
-        } else {
-          videoBitrate = videoBitrate || 0;
-        }
-
-        totalBitrate = audioBitrate + videoBitrate;
-        return totalBitrate;
       }
     }
 
-    // Fallback: Try tech-specific implementations from your wrappers
+    // Support for other tech implementations using the same formula
     const techWrapper = this.getTech();
-    if (techWrapper) {
-      if (
-        techWrapper.getBitrate &&
-        typeof techWrapper.getBitrate === 'function'
-      ) {
-        return techWrapper.getBitrate();
-      }
-
-      if (
-        techWrapper.tech &&
-        techWrapper.tech.stats &&
-        techWrapper.tech.stats.bandwidth
-      ) {
-        return techWrapper.tech.stats.bandwidth;
-      }
+    if (techWrapper?.getBitrate) {
+      return techWrapper.getBitrate();
     }
 
     return null;
@@ -277,6 +159,8 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   }
 
   getRenditionBitrate() {
+    // Returns the target bitrate from the manifest (static, changes only on rendition switch)
+    // This is different from getBitrate() which returns the actual measured bitrate
     let tech = this.getTech();
 
     if (tech && tech.getRenditionBitrate) {


### PR DESCRIPTION
Updates bitrate calculation methods to use measured throughput instead of manifest bandwidth for more accurate reporting based on actual network conditions.

## Changes
- Added getBitrate() and getContentBitratePlayback() methods across all techs
- Uses measured playback consumption rate
- Falls back to manifest bandwidth if measured data unavailable
