### PR TITLE
feat: add adTracking option for explicit ad framework declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,38 @@ if (shouldEnableTracking(currentUser.id)) {
 
 ## Configuration Options
 
+### Ad Tracking
+
+| Option        | Type   | Default       | Description                                                                                                                                         |
+| ------------- | ------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `adTracking`  | string | `'automatic'` | Controls which ad tracker is created. See values below.                                                                                             |
+| `mediatailor` | boolean / object | —   | Activates the AWS MediaTailor tracker. Pass `true` or an object with `{ trackingUrl, adSegmentPrefix }`. See [SSAI Guide](./docs/ssai.md).          |
+
+**`adTracking` values:**
+
+| Value         | Behaviour                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------ |
+| `'automatic'` | Auto-detects the ad framework in use (IMA, Brightcove IMA, Freewheel, DAI, MediaTailor). Default.     |
+| `'none'`      | Disables all ad tracking. No ad tracker is created.                                                    |
+| `'ima'`       | Only creates an IMA or Brightcove IMA tracker. Freewheel, DAI, and MediaTailor are skipped.            |
+| `'mt'`        | Only creates the AWS MediaTailor tracker. Implies `mediatailor: true` if not already set.              |
+
+```javascript
+import { AD_TRACKING } from '@newrelic/video-videojs';
+
+// Disable ad tracking entirely
+const tracker = new VideojsTracker(player, { adTracking: 'none' });
+
+// Force IMA only
+const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.IMA });
+
+// Force MediaTailor only (self-contained — no need to also pass mediatailor: true)
+const tracker = new VideojsTracker(player, { adTracking: 'mt' });
+
+// Change at runtime before the first source loads
+tracker.setAdTracking('none');
+```
+
 ### QoE (Quality of Experience) Settings
 
 | Option              | Type    | Default | Description                                                                                                                                                                              |
@@ -376,6 +408,19 @@ tracker.setOptions({
     episode: '3',
   },
 });
+```
+
+#### `tracker.setAdTracking(type)`
+
+Change the ad tracking mode after the tracker is created. Must be called before the first `loadstart` or `adsready` event to take effect.
+
+```javascript
+// Valid values: 'automatic' | 'none' | 'ima' | 'mt'
+tracker.setAdTracking('none');
+
+// Or use the exported constant to avoid magic strings
+import { AD_TRACKING } from '@newrelic/video-videojs';
+tracker.setAdTracking(AD_TRACKING.MT);
 ```
 
 ### Example: Complete Integration
@@ -480,14 +525,22 @@ The tracker automatically detects and tracks AWS MediaTailor SSAI streams. It su
 ```javascript
 import VideojsTracker from '@newrelic/video-videojs';
 
-// Initialize player with a MediaTailor playback URL
 player.src({
   src: 'https://your-mediatailor-endpoint.mediatailor.region.amazonaws.com/v1/master/...',
   type: 'application/x-mpegURL'
 });
 
-// Pass mediatailor: true to activate the MediaTailor tracker
+// Option A: explicit opt-in (existing approach)
 const tracker = new VideojsTracker(player, { mediatailor: true });
+
+// Option B: adTracking:'mt' — restricts to MediaTailor only and implies mediatailor:true
+const tracker = new VideojsTracker(player, { adTracking: 'mt' });
+
+// Option B with custom CDN config
+const tracker = new VideojsTracker(player, {
+  mediatailor: { adSegmentPrefix: '/my-cdn-path/' },
+  adTracking: 'mt',
+});
 ```
 
 The tracker will automatically:

--- a/README.md
+++ b/README.md
@@ -308,33 +308,54 @@ if (shouldEnableTracking(currentUser.id)) {
 
 ### Ad Tracking
 
-| Option        | Type             | Default       | Description                                                                                                                                |
-| ------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `adTracking`  | string           | `'automatic'` | Declares which ad tracker to use. **Always set this explicitly** — omitting it triggers a warning and falls back to automatic detection.   |
-| `mediatailor` | boolean / object | —             | Activates the AWS MediaTailor tracker. Pass `true` or an object with `{ trackingUrl, adSegmentPrefix }`. See [SSAI Guide](./docs/ssai.md). |
+The `adTracking` option declares which ad framework the tracker should wire up. **If not set, no ad tracking runs** — this is the safe default. Omitting it while passing other options triggers a console warning.
 
-**`adTracking` values:**
+Ad tracking modes are organised into two categories:
 
-| Value         | Behaviour                                                                                                                            |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `'none'`      | Disables all ad tracking. No ad tracker is created.                                                                                  |
-| `'ima'`       | Only creates an IMA or Brightcove IMA tracker. Freewheel, DAI, and MediaTailor are skipped.                                         |
-| `'mt'`        | Only creates the AWS MediaTailor tracker. Implies `mediatailor: true` if not already set.                                            |
-| `'automatic'` | Auto-detects the ad framework in use (IMA, Brightcove IMA, Freewheel, DAI, MediaTailor). Fallback only — prefer an explicit value.  |
+#### CSAI — Client-Side Ad Insertion
 
-> **Best practice:** Always declare `adTracking` explicitly. Relying on auto-detection produces a warning in the console and can result in unexpected trackers being created if multiple ad frameworks are present on the page.
+All CSAI frameworks activate through the `adsready` event. Specify the exact framework or use `CSAI.ALL` to detect the best match.
+
+| Value              | Constant                     | Behaviour                                                              |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------- |
+| `'csai'`           | `AD_TRACKING.CSAI.ALL`       | Detect best match: Brightcove IMA → IMA → Freewheel → generic         |
+| `'csai:ima'`       | `AD_TRACKING.CSAI.IMA`       | Google IMA or Brightcove IMA (ima3) only                               |
+| `'csai:freewheel'` | `AD_TRACKING.CSAI.FREEWHEEL` | Freewheel only                                                         |
+
+#### SSAI — Server-Side Ad Insertion
+
+Each SSAI platform requires its own SDK and cannot be auto-detected. **A sub-type is always required.**
+
+| Value        | Constant               | Behaviour                                                               |
+| ------------ | ---------------------- | ----------------------------------------------------------------------- |
+| `'ssai:dai'` | `AD_TRACKING.SSAI.DAI` | Google DAI (`google.ima.dai.api`)                                       |
+| `'ssai:mt'`  | `AD_TRACKING.SSAI.MT`  | AWS MediaTailor — implies `mediatailor: true` if not already set        |
 
 ```javascript
 import { AD_TRACKING } from '@newrelic/video-videojs';
 
-// Recommended: explicit declaration
-const tracker = new VideojsTracker(player, { adTracking: 'none' });
-const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.IMA });
-const tracker = new VideojsTracker(player, { adTracking: 'mt' });
+// CSAI
+new VideojsTracker(player, { adTracking: AD_TRACKING.CSAI.ALL });
+new VideojsTracker(player, { adTracking: AD_TRACKING.CSAI.IMA });
+new VideojsTracker(player, { adTracking: AD_TRACKING.CSAI.FREEWHEEL });
 
-// Change at runtime before the first source loads
-tracker.setAdTracking(AD_TRACKING.MT);
+// SSAI — sub-type required
+new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.DAI });
+new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.MT });
+
+// SSAI.MT with custom CDN config
+new VideojsTracker(player, {
+  adTracking: AD_TRACKING.SSAI.MT,
+  mediatailor: { adSegmentPrefix: '/my-cdn-path/' },
+});
+
+// Change at runtime before first loadstart / adsready
+tracker.setAdTracking(AD_TRACKING.CSAI.IMA);
 ```
+
+> **Extending later:** add a new key under `AD_TRACKING.CSAI` or `AD_TRACKING.SSAI` in `tracker.js` and handle it in the relevant detection method. No other changes needed.
+
+> **`mediatailor` option:** still accepted for MediaTailor-specific config (`trackingUrl`, `adSegmentPrefix`). See [SSAI Guide](./docs/ssai.md).
 
 ### QoE (Quality of Experience) Settings
 
@@ -413,12 +434,11 @@ tracker.setOptions({
 Change the ad tracking mode after the tracker is created. Must be called before the first `loadstart` or `adsready` event to take effect.
 
 ```javascript
-// Valid values: 'automatic' | 'none' | 'ima' | 'mt'
-tracker.setAdTracking('none');
-
-// Or use the exported constant to avoid magic strings
 import { AD_TRACKING } from '@newrelic/video-videojs';
-tracker.setAdTracking(AD_TRACKING.MT);
+
+// Valid values: 'csai' | 'csai:ima' | 'csai:freewheel' | 'ssai:dai' | 'ssai:mt'
+tracker.setAdTracking(AD_TRACKING.CSAI.IMA);
+tracker.setAdTracking(AD_TRACKING.SSAI.MT);
 ```
 
 ### Example: Complete Integration
@@ -480,73 +500,49 @@ The tracker captures four distinct bitrate metrics providing complete quality an
 
 ## Ad Tracking Support
 
-The tracker provides comprehensive ad tracking capabilities:
-
 ### Supported Ad Technologies
 
-- **IMA (Interactive Media Ads)** - Google IMA SDK integration
-- **Freewheel** - Freewheel ad platform support
-- **SSAI (Server-Side Ad Insertion)** - Dynamic Ad Insertion (DAI) support
+| Category | Framework | Constant |
+|---|---|---|
+| CSAI | Google IMA / Brightcove IMA | `AD_TRACKING.CSAI.IMA` |
+| CSAI | Freewheel | `AD_TRACKING.CSAI.FREEWHEEL` |
+| CSAI | Auto-detect (all CSAI) | `AD_TRACKING.CSAI.ALL` |
+| SSAI | Google DAI | `AD_TRACKING.SSAI.DAI` |
+| SSAI | AWS MediaTailor | `AD_TRACKING.SSAI.MT` |
 
-### SSAI/DAI Integration
+See [Configuration Options → Ad Tracking](#ad-tracking) for full usage and examples.
 
-Server-Side Ad Insertion is supported with automatic tracker selection for supported integrations:
+### Google DAI Integration
 
 ```javascript
-// SSAI tracker selection is automatic for supported integrations
-const tracker = new VideojsTracker(player, options);
+import { AD_TRACKING } from '@newrelic/video-videojs';
 
-// The tracker will automatically capture:
-// - Ad breaks, starts, and completions
-// - Ad quartiles and click events
-// - SSAI-specific metadata when available
+const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.DAI });
 ```
 
-**Example:** See [samples/dai/index.html](./samples/dai/index.html) for a complete SSAI implementation.
-
-> [!NOTE]
-> **Attention:**
-> This version supports tracking for SSAI (Server-Side Ad Insertion), including AWS MediaTailor. See [samples/media-tailor-lab.html](./samples/media-tailor-lab.html) and the [SSAI Guide](./docs/ssai.md).
+See [samples/dai/index.html](./samples/dai/index.html) for a complete example.
 
 ### AWS MediaTailor Integration
 
-The tracker automatically detects and tracks AWS MediaTailor SSAI streams. It supports:
-
-- **HLS and DASH** manifest formats
-- **VOD and LIVE** stream types
-- **Multiple ads (pods)** within a single break
-- **Quartile tracking** (25%, 50%, 75%)
-- **Tracking metadata enrichment** when MediaTailor tracking data is available
-
-#### Usage
+Supports HLS/DASH, VOD/LIVE, multiple ads per break, quartile tracking, and tracking metadata enrichment.
 
 ```javascript
-import VideojsTracker from '@newrelic/video-videojs';
+import { AD_TRACKING } from '@newrelic/video-videojs';
 
 player.src({
   src: 'https://your-mediatailor-endpoint.mediatailor.region.amazonaws.com/v1/master/...',
   type: 'application/x-mpegURL'
 });
 
-// Option A: explicit opt-in (existing approach)
-const tracker = new VideojsTracker(player, { mediatailor: true });
+// Standard setup
+const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.MT });
 
-// Option B: adTracking:'mt' — restricts to MediaTailor only and implies mediatailor:true
-const tracker = new VideojsTracker(player, { adTracking: 'mt' });
-
-// Option B with custom CDN config
+// With custom CDN config
 const tracker = new VideojsTracker(player, {
+  adTracking: AD_TRACKING.SSAI.MT,
   mediatailor: { adSegmentPrefix: '/my-cdn-path/' },
-  adTracking: 'mt',
 });
 ```
-
-The tracker will automatically:
-1. Detect whether the manifest format is HLS or DASH
-2. Detect whether playback is VOD or LIVE
-3. Parse manifests for ad breaks and distinguish ad segments from content segments
-4. Track ad breaks, ad starts, quartiles, and ad ends
-5. Enrich ad metadata when tracking data is available
 
 Works with default AWS hostnames and custom CDN domains. See [docs/ssai.md](./docs/ssai.md) for custom CDN setup and advanced options.
 

--- a/README.md
+++ b/README.md
@@ -308,34 +308,32 @@ if (shouldEnableTracking(currentUser.id)) {
 
 ### Ad Tracking
 
-| Option        | Type   | Default       | Description                                                                                                                                         |
-| ------------- | ------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `adTracking`  | string | `'automatic'` | Controls which ad tracker is created. See values below.                                                                                             |
-| `mediatailor` | boolean / object | —   | Activates the AWS MediaTailor tracker. Pass `true` or an object with `{ trackingUrl, adSegmentPrefix }`. See [SSAI Guide](./docs/ssai.md).          |
+| Option        | Type             | Default       | Description                                                                                                                                |
+| ------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `adTracking`  | string           | `'automatic'` | Declares which ad tracker to use. **Always set this explicitly** — omitting it triggers a warning and falls back to automatic detection.   |
+| `mediatailor` | boolean / object | —             | Activates the AWS MediaTailor tracker. Pass `true` or an object with `{ trackingUrl, adSegmentPrefix }`. See [SSAI Guide](./docs/ssai.md). |
 
 **`adTracking` values:**
 
-| Value         | Behaviour                                                                                              |
-| ------------- | ------------------------------------------------------------------------------------------------------ |
-| `'automatic'` | Auto-detects the ad framework in use (IMA, Brightcove IMA, Freewheel, DAI, MediaTailor). Default.     |
-| `'none'`      | Disables all ad tracking. No ad tracker is created.                                                    |
-| `'ima'`       | Only creates an IMA or Brightcove IMA tracker. Freewheel, DAI, and MediaTailor are skipped.            |
-| `'mt'`        | Only creates the AWS MediaTailor tracker. Implies `mediatailor: true` if not already set.              |
+| Value         | Behaviour                                                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `'none'`      | Disables all ad tracking. No ad tracker is created.                                                                                  |
+| `'ima'`       | Only creates an IMA or Brightcove IMA tracker. Freewheel, DAI, and MediaTailor are skipped.                                         |
+| `'mt'`        | Only creates the AWS MediaTailor tracker. Implies `mediatailor: true` if not already set.                                            |
+| `'automatic'` | Auto-detects the ad framework in use (IMA, Brightcove IMA, Freewheel, DAI, MediaTailor). Fallback only — prefer an explicit value.  |
+
+> **Best practice:** Always declare `adTracking` explicitly. Relying on auto-detection produces a warning in the console and can result in unexpected trackers being created if multiple ad frameworks are present on the page.
 
 ```javascript
 import { AD_TRACKING } from '@newrelic/video-videojs';
 
-// Disable ad tracking entirely
+// Recommended: explicit declaration
 const tracker = new VideojsTracker(player, { adTracking: 'none' });
-
-// Force IMA only
 const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.IMA });
-
-// Force MediaTailor only (self-contained — no need to also pass mediatailor: true)
 const tracker = new VideojsTracker(player, { adTracking: 'mt' });
 
 // Change at runtime before the first source loads
-tracker.setAdTracking('none');
+tracker.setAdTracking(AD_TRACKING.MT);
 ```
 
 ### QoE (Quality of Experience) Settings

--- a/README.md
+++ b/README.md
@@ -308,23 +308,19 @@ if (shouldEnableTracking(currentUser.id)) {
 
 ### Ad Tracking
 
-The `adTracking` option declares which ad framework the tracker should wire up. **If not set, no ad tracking runs** — this is the safe default. Omitting it while passing other options triggers a console warning.
-
-Ad tracking modes are organised into two categories:
+The `adTracking` option declares which ad category the tracker should wire up. **If not set, no ad tracking runs** — this is the safe default. Omitting it while passing other options triggers a console warning.
 
 #### CSAI — Client-Side Ad Insertion
 
-All CSAI frameworks activate through the `adsready` event. Specify the exact framework or use `CSAI.ALL` to detect the best match.
+All CSAI frameworks (IMA, Brightcove IMA, Freewheel) share the `adsready` event path. The tracker auto-detects which one is present — no sub-type needed. Just declare `CSAI`.
 
-| Value              | Constant                     | Behaviour                                                              |
-| ------------------ | ---------------------------- | ---------------------------------------------------------------------- |
-| `'csai'`           | `AD_TRACKING.CSAI.ALL`       | Detect best match: Brightcove IMA → IMA → Freewheel → generic         |
-| `'csai:ima'`       | `AD_TRACKING.CSAI.IMA`       | Google IMA or Brightcove IMA (ima3) only                               |
-| `'csai:freewheel'` | `AD_TRACKING.CSAI.FREEWHEEL` | Freewheel only                                                         |
+| Value    | Constant         | Behaviour                                                                  |
+| -------- | ---------------- | -------------------------------------------------------------------------- |
+| `'csai'` | `AD_TRACKING.CSAI` | Auto-detects: Brightcove IMA → IMA → Freewheel → generic fallback       |
 
 #### SSAI — Server-Side Ad Insertion
 
-Each SSAI platform requires its own SDK and cannot be auto-detected. **A sub-type is always required.**
+Each SSAI platform has its own SDK and a completely different activation path — they cannot be auto-detected. **A sub-type is always required.**
 
 | Value        | Constant               | Behaviour                                                               |
 | ------------ | ---------------------- | ----------------------------------------------------------------------- |
@@ -334,12 +330,10 @@ Each SSAI platform requires its own SDK and cannot be auto-detected. **A sub-typ
 ```javascript
 import { AD_TRACKING } from '@newrelic/video-videojs';
 
-// CSAI
-new VideojsTracker(player, { adTracking: AD_TRACKING.CSAI.ALL });
-new VideojsTracker(player, { adTracking: AD_TRACKING.CSAI.IMA });
-new VideojsTracker(player, { adTracking: AD_TRACKING.CSAI.FREEWHEEL });
+// CSAI — one value covers all client-side frameworks
+new VideojsTracker(player, { adTracking: AD_TRACKING.CSAI });
 
-// SSAI — sub-type required
+// SSAI — sub-type always required
 new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.DAI });
 new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.MT });
 
@@ -350,10 +344,10 @@ new VideojsTracker(player, {
 });
 
 // Change at runtime before first loadstart / adsready
-tracker.setAdTracking(AD_TRACKING.CSAI.IMA);
+tracker.setAdTracking(AD_TRACKING.CSAI);
 ```
 
-> **Extending later:** add a new key under `AD_TRACKING.CSAI` or `AD_TRACKING.SSAI` in `tracker.js` and handle it in the relevant detection method. No other changes needed.
+> **Extending later:** add a new key to `AD_TRACKING.SSAI` — validation derives from the object automatically. No other changes needed.
 
 > **`mediatailor` option:** still accepted for MediaTailor-specific config (`trackingUrl`, `adSegmentPrefix`). See [SSAI Guide](./docs/ssai.md).
 
@@ -436,8 +430,8 @@ Change the ad tracking mode after the tracker is created. Must be called before 
 ```javascript
 import { AD_TRACKING } from '@newrelic/video-videojs';
 
-// Valid values: 'csai' | 'csai:ima' | 'csai:freewheel' | 'ssai:dai' | 'ssai:mt'
-tracker.setAdTracking(AD_TRACKING.CSAI.IMA);
+// Valid values: 'csai' | 'ssai:dai' | 'ssai:mt'
+tracker.setAdTracking(AD_TRACKING.CSAI);
 tracker.setAdTracking(AD_TRACKING.SSAI.MT);
 ```
 
@@ -502,11 +496,9 @@ The tracker captures four distinct bitrate metrics providing complete quality an
 
 ### Supported Ad Technologies
 
-| Category | Framework | Constant |
+| Category | Frameworks detected | Constant |
 |---|---|---|
-| CSAI | Google IMA / Brightcove IMA | `AD_TRACKING.CSAI.IMA` |
-| CSAI | Freewheel | `AD_TRACKING.CSAI.FREEWHEEL` |
-| CSAI | Auto-detect (all CSAI) | `AD_TRACKING.CSAI.ALL` |
+| CSAI | Google IMA, Brightcove IMA, Freewheel, generic | `AD_TRACKING.CSAI` |
 | SSAI | Google DAI | `AD_TRACKING.SSAI.DAI` |
 | SSAI | AWS MediaTailor | `AD_TRACKING.SSAI.MT` |
 
@@ -516,7 +508,6 @@ See [Configuration Options → Ad Tracking](#ad-tracking) for full usage and exa
 
 ```javascript
 import { AD_TRACKING } from '@newrelic/video-videojs';
-
 const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.DAI });
 ```
 
@@ -534,7 +525,6 @@ player.src({
   type: 'application/x-mpegURL'
 });
 
-// Standard setup
 const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.MT });
 
 // With custom CDN config

--- a/docs/ssai.md
+++ b/docs/ssai.md
@@ -16,30 +16,24 @@ Customers should already have:
 
 ## Activation
 
-There are two ways to activate the MediaTailor tracker:
-
-**Option A — `mediatailor: true`** (existing approach, backward-compatible):
+Use `adTracking: AD_TRACKING.SSAI.MT` to activate the MediaTailor tracker. This is the standard approach — it declares intent explicitly and ensures no other ad tracker is created alongside it.
 
 ```javascript
-const tracker = new VideojsTracker(player, { mediatailor: true });
+import { AD_TRACKING } from '@newrelic/video-videojs';
+
+const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.MT });
 ```
 
-**Option B — `adTracking: 'mt'`** (new, self-contained shorthand):
-
-```javascript
-const tracker = new VideojsTracker(player, { adTracking: 'mt' });
-```
-
-`adTracking: 'mt'` implies `mediatailor: true` automatically, so there is no need to pass both. It also restricts the tracker so that no IMA, Freewheel, DAI, or generic ad tracker can be created — useful when you want to make the intent explicit in your code.
-
-If you need custom CDN config alongside the explicit mode, pass both:
+`AD_TRACKING.SSAI.MT` implies `mediatailor: true` internally, so you do not need to pass it separately. If you need custom CDN config, pass it via the `mediatailor` option alongside `adTracking`:
 
 ```javascript
 const tracker = new VideojsTracker(player, {
+  adTracking: AD_TRACKING.SSAI.MT,
   mediatailor: { adSegmentPrefix: '/your-path/' },
-  adTracking: 'mt',
 });
 ```
+
+> **SSAI always requires a sub-type.** There is no `AD_TRACKING.SSAI.ALL` — each SSAI platform (MediaTailor, Google DAI) needs its own SDK and cannot be auto-detected. Always declare which one you are using.
 
 ## What The Tracker Does Automatically
 
@@ -104,7 +98,7 @@ Some metadata can arrive after playback has already started if it is filled in f
 
 If MediaTailor tracking does not activate, verify:
 
-1. Either `mediatailor: true` or `adTracking: 'mt'` is passed in the tracker options.
+1. `adTracking: AD_TRACKING.SSAI.MT` is passed in the tracker options.
 2. Segment requests are reaching the player (check the Network tab).
 3. If using a custom CDN ad-segment path, verify `adSegmentPrefix` matches the path configured in the AWS MediaTailor console.
 

--- a/docs/ssai.md
+++ b/docs/ssai.md
@@ -16,10 +16,29 @@ Customers should already have:
 
 ## Activation
 
-Pass `mediatailor: true` when initialising the tracker. This is required for all setups — default AWS hostnames and custom CDN domains alike.
+There are two ways to activate the MediaTailor tracker:
+
+**Option A — `mediatailor: true`** (existing approach, backward-compatible):
 
 ```javascript
 const tracker = new VideojsTracker(player, { mediatailor: true });
+```
+
+**Option B — `adTracking: 'mt'`** (new, self-contained shorthand):
+
+```javascript
+const tracker = new VideojsTracker(player, { adTracking: 'mt' });
+```
+
+`adTracking: 'mt'` implies `mediatailor: true` automatically, so there is no need to pass both. It also restricts the tracker so that no IMA, Freewheel, DAI, or generic ad tracker can be created — useful when you want to make the intent explicit in your code.
+
+If you need custom CDN config alongside the explicit mode, pass both:
+
+```javascript
+const tracker = new VideojsTracker(player, {
+  mediatailor: { adSegmentPrefix: '/your-path/' },
+  adTracking: 'mt',
+});
 ```
 
 ## What The Tracker Does Automatically
@@ -85,7 +104,7 @@ Some metadata can arrive after playback has already started if it is filled in f
 
 If MediaTailor tracking does not activate, verify:
 
-1. `mediatailor: true` is passed in the tracker options.
+1. Either `mediatailor: true` or `adTracking: 'mt'` is passed in the tracker options.
 2. Segment requests are reaching the player (check the Network tab).
 3. If using a custom CDN ad-segment path, verify `adSegmentPrefix` matches the path configured in the AWS MediaTailor console.
 

--- a/docs/ssai.md
+++ b/docs/ssai.md
@@ -16,7 +16,7 @@ Customers should already have:
 
 ## Activation
 
-Use `adTracking: AD_TRACKING.SSAI.MT` to activate the MediaTailor tracker. This is the standard approach — it declares intent explicitly and ensures no other ad tracker is created alongside it.
+Use `adTracking: AD_TRACKING.SSAI.MT` to activate the MediaTailor tracker. SSAI platforms cannot be auto-detected — each one has its own SDK and activation path, so declaring the sub-type is always required.
 
 ```javascript
 import { AD_TRACKING } from '@newrelic/video-videojs';
@@ -24,7 +24,7 @@ import { AD_TRACKING } from '@newrelic/video-videojs';
 const tracker = new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.MT });
 ```
 
-`AD_TRACKING.SSAI.MT` implies `mediatailor: true` internally, so you do not need to pass it separately. If you need custom CDN config, pass it via the `mediatailor` option alongside `adTracking`:
+`AD_TRACKING.SSAI.MT` implies `mediatailor: true` internally, so you do not need to pass it separately. If you need custom CDN config, pass it via the `mediatailor` option:
 
 ```javascript
 const tracker = new VideojsTracker(player, {
@@ -32,8 +32,6 @@ const tracker = new VideojsTracker(player, {
   mediatailor: { adSegmentPrefix: '/your-path/' },
 });
 ```
-
-> **SSAI always requires a sub-type.** There is no `AD_TRACKING.SSAI.ALL` — each SSAI platform (MediaTailor, Google DAI) needs its own SDK and cannot be auto-detected. Always declare which one you are using.
 
 ## What The Tracker Does Automatically
 

--- a/src/register-plugin.js
+++ b/src/register-plugin.js
@@ -12,8 +12,8 @@ if (typeof videojs !== 'undefined') {
    */
   registerPlugin('newrelic', function (options) {
     if (!this.newrelictracker) {
-      this.newrelictracker = new nrvideo.VideojsTracker(this);
-      nrvideo.Core.addTracker(this.newrelictracker);
+      this.newrelictracker = new nrvideo.VideojsTracker(this, options);
+      nrvideo.Core.addTracker(this.newrelictracker, options);
     }
     return this.newrelictracker;
   });

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -14,28 +14,24 @@ import MediaTailorAdsTracker from './ads/media-tailor';
  * Explicit ad tracking modes.
  *
  * CSAI (Client-Side Ad Insertion)
- *   CSAI.ALL       — detect best match in order: Brightcove IMA → IMA → Freewheel → generic
- *   CSAI.IMA       — Google IMA or Brightcove IMA (ima3) only
- *   CSAI.FREEWHEEL — Freewheel only
+ *   All CSAI frameworks share the adsready event path. The tracker auto-detects
+ *   the right framework (Brightcove IMA → IMA → Freewheel → generic) — no sub-type needed.
  *
  * SSAI (Server-Side Ad Insertion) — sub-type is always required.
- *   Each SSAI platform needs its own SDK and cannot be auto-detected.
+ *   Each SSAI platform has its own SDK and a different activation path.
+ *   Cannot be auto-detected — declare which one you are using.
  *   SSAI.DAI — Google DAI (google.ima.dai.api)
  *   SSAI.MT  — AWS MediaTailor (implies mediatailor: true if not already set)
  *
  * If adTracking is not set, no ad tracking runs (safe default).
- * Extend by adding new keys to CSAI or SSAI — validation derives from this object.
+ * To add a new SSAI platform: add a key to SSAI — validation derives from this object.
  */
 export const AD_TRACKING = {
-  CSAI: {
-    ALL:       'csai',
-    IMA:       'csai:ima',
-    FREEWHEEL: 'csai:freewheel',
-  },
-  SSAI: {
+  CSAI: 'csai',
+  SSAI: Object.freeze({
     DAI: 'ssai:dai',
     MT:  'ssai:mt',
-  },
+  }),
 };
 
 export default class VideojsTracker extends nrvideo.VideoTracker {
@@ -52,7 +48,7 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
     if (options && !options.adTracking) {
       nrvideo.Log.warn(
         'VideojsTracker: adTracking not set — no ad tracking will run. ' +
-        'Set adTracking to enable it (e.g. AD_TRACKING.CSAI.IMA, AD_TRACKING.SSAI.MT).'
+        'Set adTracking to enable it (e.g. AD_TRACKING.CSAI, AD_TRACKING.SSAI.MT).'
       );
     }
 
@@ -68,10 +64,13 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   /**
    * Sets the ad tracking mode at runtime.
    * Must be called before the first loadstart / adsready event to take effect.
-   * @param {'csai'|'csai:ima'|'csai:freewheel'|'ssai:dai'|'ssai:mt'} type
+   * @param {'csai'|'ssai:dai'|'ssai:mt'} type
    */
   setAdTracking(type) {
-    const valid = Object.values(AD_TRACKING).flatMap(group => Object.values(group));
+    const valid = [
+      AD_TRACKING.CSAI,
+      ...Object.values(AD_TRACKING.SSAI),
+    ];
     if (!valid.includes(type)) {
       nrvideo.Log.warn(
         `VideojsTracker.setAdTracking: unknown value "${type}". Valid values: ${valid.join(', ')}`
@@ -415,24 +414,19 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   // DAI methods end
 
   onAdsready() {
-    // Only CSAI modes go through the adsready path.
-    // null (not set) or SSAI values → no tracking, skip.
-    if (!this.adTracking || !this.adTracking.startsWith('csai')) return;
+    // Only CSAI goes through the adsready path — SSAI platforms use different events.
+    // No sub-type needed: all CSAI frameworks share this path and are auto-detected.
+    if (this.adTracking !== AD_TRACKING.CSAI) return;
 
     if (!this.adsTracker) {
-      const all = this.adTracking === AD_TRACKING.CSAI.ALL;
-      const isIma = all || this.adTracking === AD_TRACKING.CSAI.IMA;
-      const isFw  = all || this.adTracking === AD_TRACKING.CSAI.FREEWHEEL;
-
-      if (isIma && BrightcoveImaAdsTracker.isUsing(this.player)) {
+      if (BrightcoveImaAdsTracker.isUsing(this.player)) {
         this.setAdsTracker(new BrightcoveImaAdsTracker(this.player));
-      } else if (isIma && ImaAdsTracker.isUsing(this.player)) {
+      } else if (ImaAdsTracker.isUsing(this.player)) {
         this.setAdsTracker(new ImaAdsTracker(this.player));
-      } else if (isFw && FreewheelAdsTracker.isUsing(this.player)) {
+      } else if (FreewheelAdsTracker.isUsing(this.player)) {
         // } else if (OnceAdsTracker.isUsing(this)) { // Once
         this.setAdsTracker(new FreewheelAdsTracker(this.player));
-      } else if (all) {
-        // Generic contrib-ads fallback — only under CSAI.ALL
+      } else {
         this.setAdsTracker(new VideojsAdsTracker(this.player));
       }
     }

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -11,17 +11,31 @@ import DaiAdsTracker from './ads/dai';
 import MediaTailorAdsTracker from './ads/media-tailor';
 
 /**
- * Controls which ad tracker (if any) is created automatically.
- *   automatic — auto-detect all frameworks (default, backward-compatible)
- *   none      — disable all ad tracking
- *   ima       — only IMA / Brightcove IMA trackers
- *   mt        — only AWS MediaTailor tracker
+ * Explicit ad tracking modes.
+ *
+ * CSAI (Client-Side Ad Insertion)
+ *   CSAI.ALL       — detect best match in order: Brightcove IMA → IMA → Freewheel → generic
+ *   CSAI.IMA       — Google IMA or Brightcove IMA (ima3) only
+ *   CSAI.FREEWHEEL — Freewheel only
+ *
+ * SSAI (Server-Side Ad Insertion) — sub-type is always required.
+ *   Each SSAI platform needs its own SDK and cannot be auto-detected.
+ *   SSAI.DAI — Google DAI (google.ima.dai.api)
+ *   SSAI.MT  — AWS MediaTailor (implies mediatailor: true if not already set)
+ *
+ * If adTracking is not set, no ad tracking runs (safe default).
+ * Extend by adding new keys to CSAI or SSAI — validation derives from this object.
  */
 export const AD_TRACKING = {
-  AUTOMATIC: 'automatic',
-  NONE: 'none',
-  IMA: 'ima',
-  MT: 'mt',
+  CSAI: {
+    ALL:       'csai',
+    IMA:       'csai:ima',
+    FREEWHEEL: 'csai:freewheel',
+  },
+  SSAI: {
+    DAI: 'ssai:dai',
+    MT:  'ssai:mt',
+  },
 };
 
 export default class VideojsTracker extends nrvideo.VideoTracker {
@@ -31,21 +45,20 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
     this.isContentEnd = false;
     this.imaAdCuePoints = '';
     this.daiInitialized = false;
-    this.adTracking = (options && options.adTracking) || AD_TRACKING.AUTOMATIC;
+    this.adTracking = (options && options.adTracking) || null;
 
-    // Warn when options are provided but adTracking is not explicitly set.
-    // Enterprise integrations should declare intent rather than relying on auto-detection.
-    if (options && options.adTracking === undefined) {
+    // When options are provided but adTracking is not declared, no ad tracking
+    // will run. Warn so the caller knows to set it explicitly.
+    if (options && !options.adTracking) {
       nrvideo.Log.warn(
-        'VideojsTracker: adTracking not specified — falling back to automatic ad framework ' +
-        'detection. Set adTracking explicitly (e.g. "ima", "mt", "none") for deterministic behaviour.'
+        'VideojsTracker: adTracking not set — no ad tracking will run. ' +
+        'Set adTracking to enable it (e.g. AD_TRACKING.CSAI.IMA, AD_TRACKING.SSAI.MT).'
       );
     }
 
-    // adTracking:'mt' is self-contained — it implies mediatailor activation.
-    // Normalize so MediaTailorAdsTracker.isUsing() returns true without requiring
-    // the user to also pass mediatailor:true separately.
-    if (this.adTracking === AD_TRACKING.MT && !(this.options && this.options.mediatailor)) {
+    // SSAI.MT is self-contained — implies mediatailor:true so the MT tracker
+    // activates without requiring a separate mediatailor option.
+    if (this.adTracking === AD_TRACKING.SSAI.MT && !(this.options && this.options.mediatailor)) {
       this.options = Object.assign({}, this.options, { mediatailor: true });
     }
 
@@ -55,18 +68,18 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   /**
    * Sets the ad tracking mode at runtime.
    * Must be called before the first loadstart / adsready event to take effect.
-   * @param {'automatic'|'none'|'ima'|'mt'} type
+   * @param {'csai'|'csai:ima'|'csai:freewheel'|'ssai:dai'|'ssai:mt'} type
    */
   setAdTracking(type) {
-    const valid = Object.values(AD_TRACKING);
+    const valid = Object.values(AD_TRACKING).flatMap(group => Object.values(group));
     if (!valid.includes(type)) {
       nrvideo.Log.warn(
-        `VideojsTracker.setAdTracking: unknown type "${type}". Valid values: ${valid.join(', ')}`
+        `VideojsTracker.setAdTracking: unknown value "${type}". Valid values: ${valid.join(', ')}`
       );
       return;
     }
     this.adTracking = type;
-    if (type === AD_TRACKING.MT && !(this.options && this.options.mediatailor)) {
+    if (type === AD_TRACKING.SSAI.MT && !(this.options && this.options.mediatailor)) {
       this.options = Object.assign({}, this.options, { mediatailor: true });
     }
     nrvideo.Log.debug(`VideojsTracker: adTracking set to "${type}"`);
@@ -375,19 +388,14 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   onDownload(e) {
     this.sendDownload({ state: e.type });
 
-    // Only attempt MediaTailor detection when adTracking allows it and on loadstart
     if (
-      this.adTracking !== AD_TRACKING.NONE &&
-      this.adTracking !== AD_TRACKING.IMA &&
+      this.adTracking === AD_TRACKING.SSAI.MT &&
       !this.adsTracker &&
-      e.type === 'loadstart' &&
-      MediaTailorAdsTracker.isUsing(this.player, this.options)
+      e.type === 'loadstart'
     ) {
-      nrvideo.Log.debug(
-        'VideojsTracker: Creating MediaTailorAdsTracker after source load'
-      );
+      nrvideo.Log.debug('VideojsTracker: Creating MediaTailorAdsTracker');
       this.setAdsTracker(new MediaTailorAdsTracker(this.player, this.options));
-      // MediaTailor SSAI starts with content, not ads (unlike client-side ad frameworks)
+      // MediaTailor SSAI starts with content, not ads (unlike client-side frameworks)
       this.adsTracker.setIsAd(false);
     }
   }
@@ -395,7 +403,7 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   // DAI methods
   onStreamManager(event) {
     if (
-      this.adTracking === AD_TRACKING.AUTOMATIC &&
+      this.adTracking === AD_TRACKING.SSAI.DAI &&
       !this.adsTracker &&
       event.StreamManager
     ) {
@@ -407,30 +415,24 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   // DAI methods end
 
   onAdsready() {
-    // 'none' and 'mt' modes do not use client-side ad frameworks
-    if (
-      this.adTracking === AD_TRACKING.NONE ||
-      this.adTracking === AD_TRACKING.MT
-    ) {
-      return;
-    }
+    // Only CSAI modes go through the adsready path.
+    // null (not set) or SSAI values → no tracking, skip.
+    if (!this.adTracking || !this.adTracking.startsWith('csai')) return;
 
     if (!this.adsTracker) {
-      if (BrightcoveImaAdsTracker.isUsing(this.player)) {
-        // BC IMA
+      const all = this.adTracking === AD_TRACKING.CSAI.ALL;
+      const isIma = all || this.adTracking === AD_TRACKING.CSAI.IMA;
+      const isFw  = all || this.adTracking === AD_TRACKING.CSAI.FREEWHEEL;
+
+      if (isIma && BrightcoveImaAdsTracker.isUsing(this.player)) {
         this.setAdsTracker(new BrightcoveImaAdsTracker(this.player));
-      } else if (ImaAdsTracker.isUsing(this.player)) {
-        // IMA
+      } else if (isIma && ImaAdsTracker.isUsing(this.player)) {
         this.setAdsTracker(new ImaAdsTracker(this.player));
-      } else if (
-        this.adTracking === AD_TRACKING.AUTOMATIC &&
-        FreewheelAdsTracker.isUsing(this.player)
-      ) {
-        // FW — only under automatic mode (not when explicitly requesting IMA)
-        this.setAdsTracker(new FreewheelAdsTracker(this.player));
+      } else if (isFw && FreewheelAdsTracker.isUsing(this.player)) {
         // } else if (OnceAdsTracker.isUsing(this)) { // Once
-      } else if (this.adTracking === AD_TRACKING.AUTOMATIC) {
-        // Generic — only under automatic mode
+        this.setAdsTracker(new FreewheelAdsTracker(this.player));
+      } else if (all) {
+        // Generic contrib-ads fallback — only under CSAI.ALL
         this.setAdsTracker(new VideojsAdsTracker(this.player));
       }
     }
@@ -558,5 +560,6 @@ export {
   ImaAdsTracker,
   BrightcoveImaAdsTracker,
   FreewheelAdsTracker,
+  DaiAdsTracker,
   MediaTailorAdsTracker,
 };

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -10,6 +10,20 @@ import FreewheelAdsTracker from './ads/freewheel';
 import DaiAdsTracker from './ads/dai';
 import MediaTailorAdsTracker from './ads/media-tailor';
 
+/**
+ * Controls which ad tracker (if any) is created automatically.
+ *   automatic — auto-detect all frameworks (default, backward-compatible)
+ *   none      — disable all ad tracking
+ *   ima       — only IMA / Brightcove IMA trackers
+ *   mt        — only AWS MediaTailor tracker
+ */
+export const AD_TRACKING = {
+  AUTOMATIC: 'automatic',
+  NONE: 'none',
+  IMA: 'ima',
+  MT: 'mt',
+};
+
 export default class VideojsTracker extends nrvideo.VideoTracker {
   constructor(player, options) {
     super(player, options);
@@ -17,7 +31,36 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
     this.isContentEnd = false;
     this.imaAdCuePoints = '';
     this.daiInitialized = false;
+    this.adTracking = (options && options.adTracking) || AD_TRACKING.AUTOMATIC;
+
+    // adTracking:'mt' is self-contained — it implies mediatailor activation.
+    // Normalize so MediaTailorAdsTracker.isUsing() returns true without requiring
+    // the user to also pass mediatailor:true separately.
+    if (this.adTracking === AD_TRACKING.MT && !(this.options && this.options.mediatailor)) {
+      this.options = Object.assign({}, this.options, { mediatailor: true });
+    }
+
     nrvideo.Core.addTracker(this, options);
+  }
+
+  /**
+   * Sets the ad tracking mode at runtime.
+   * Must be called before the first loadstart / adsready event to take effect.
+   * @param {'automatic'|'none'|'ima'|'mt'} type
+   */
+  setAdTracking(type) {
+    const valid = Object.values(AD_TRACKING);
+    if (!valid.includes(type)) {
+      nrvideo.Log.warn(
+        `VideojsTracker.setAdTracking: unknown type "${type}". Valid values: ${valid.join(', ')}`
+      );
+      return;
+    }
+    this.adTracking = type;
+    if (type === AD_TRACKING.MT && !(this.options && this.options.mediatailor)) {
+      this.options = Object.assign({}, this.options, { mediatailor: true });
+    }
+    nrvideo.Log.debug(`VideojsTracker: adTracking set to "${type}"`);
   }
 
   getTech() {
@@ -323,9 +366,10 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   onDownload(e) {
     this.sendDownload({ state: e.type });
 
-    // Check if MediaTailor should be used after the source is loaded
-    // Only check on 'loadstart' to avoid multiple checks
+    // Only attempt MediaTailor detection when adTracking allows it and on loadstart
     if (
+      this.adTracking !== AD_TRACKING.NONE &&
+      this.adTracking !== AD_TRACKING.IMA &&
       !this.adsTracker &&
       e.type === 'loadstart' &&
       MediaTailorAdsTracker.isUsing(this.player, this.options)
@@ -341,7 +385,11 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
 
   // DAI methods
   onStreamManager(event) {
-    if (!this.adsTracker && event.StreamManager) {
+    if (
+      this.adTracking === AD_TRACKING.AUTOMATIC &&
+      !this.adsTracker &&
+      event.StreamManager
+    ) {
       const daiTracker = new DaiAdsTracker(this.player);
       daiTracker.setStreamManager(event.StreamManager);
       this.setAdsTracker(daiTracker);
@@ -350,6 +398,14 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   // DAI methods end
 
   onAdsready() {
+    // 'none' and 'mt' modes do not use client-side ad frameworks
+    if (
+      this.adTracking === AD_TRACKING.NONE ||
+      this.adTracking === AD_TRACKING.MT
+    ) {
+      return;
+    }
+
     if (!this.adsTracker) {
       if (BrightcoveImaAdsTracker.isUsing(this.player)) {
         // BC IMA
@@ -357,13 +413,15 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
       } else if (ImaAdsTracker.isUsing(this.player)) {
         // IMA
         this.setAdsTracker(new ImaAdsTracker(this.player));
-      } else if (FreewheelAdsTracker.isUsing(this.player)) {
-        // FW
-
+      } else if (
+        this.adTracking === AD_TRACKING.AUTOMATIC &&
+        FreewheelAdsTracker.isUsing(this.player)
+      ) {
+        // FW — only under automatic mode (not when explicitly requesting IMA)
         this.setAdsTracker(new FreewheelAdsTracker(this.player));
         // } else if (OnceAdsTracker.isUsing(this)) { // Once
-      } else {
-        // Generic
+      } else if (this.adTracking === AD_TRACKING.AUTOMATIC) {
+        // Generic — only under automatic mode
         this.setAdsTracker(new VideojsAdsTracker(this.player));
       }
     }
@@ -483,6 +541,7 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
 
 // Static members
 export {
+  AD_TRACKING,
   HlsJsTech,
   ContribHlsTech,
   ShakaTech,

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -33,6 +33,15 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
     this.daiInitialized = false;
     this.adTracking = (options && options.adTracking) || AD_TRACKING.AUTOMATIC;
 
+    // Warn when options are provided but adTracking is not explicitly set.
+    // Enterprise integrations should declare intent rather than relying on auto-detection.
+    if (options && options.adTracking === undefined) {
+      nrvideo.Log.warn(
+        'VideojsTracker: adTracking not specified — falling back to automatic ad framework ' +
+        'detection. Set adTracking explicitly (e.g. "ima", "mt", "none") for deterministic behaviour.'
+      );
+    }
+
     // adTracking:'mt' is self-contained — it implies mediatailor activation.
     // Normalize so MediaTailorAdsTracker.isUsing() returns true without requiring
     // the user to also pass mediatailor:true separately.


### PR DESCRIPTION
## Summary

Adds an `adTracking` option and `setAdTracking()` method so callers explicitly declare which ad framework they are using.

Ad tracking modes are split into two categories:

### CSAI — Client-Side Ad Insertion

All CSAI frameworks share the `adsready` event path and are auto-detected. One value covers all of them.

| Value | Constant | Behaviour |
|---|---|---|
| `'csai'` | `AD_TRACKING.CSAI` | Auto-detects: Brightcove IMA → IMA → Freewheel → generic |

### SSAI — Server-Side Ad Insertion

Each SSAI platform has its own SDK and activation path. Sub-type is always required.

| Value | Constant | Behaviour |
|---|---|---|
| `'ssai:dai'` | `AD_TRACKING.SSAI.DAI` | Google DAI |
| `'ssai:mt'` | `AD_TRACKING.SSAI.MT` | AWS MediaTailor — implies `mediatailor: true` |

```js
import { AD_TRACKING } from '@newrelic/video-videojs';

new VideojsTracker(player, { adTracking: AD_TRACKING.CSAI });
new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.DAI });
new VideojsTracker(player, { adTracking: AD_TRACKING.SSAI.MT });

// With custom CDN config
new VideojsTracker(player, {
  adTracking: AD_TRACKING.SSAI.MT,
  mediatailor: { adSegmentPrefix: '/my-cdn-path/' },
});

// Change at runtime before first loadstart / adsready
tracker.setAdTracking(AD_TRACKING.CSAI);
```

## Behaviour when not set

If `adTracking` is not set, no ad tracking runs. A `Log.warn` is emitted when options are passed without `adTracking` to guide the caller.

## Extensibility

To add a new SSAI platform, add a key to `AD_TRACKING.SSAI`. Validation derives from the constant automatically.

## Bug fix

`register-plugin.js` was not forwarding `options` to the `VideojsTracker` constructor when using the VideoJS plugin registration path. Fixed.

## Notes

- Builds on top of #106
- No breaking changes — existing `mediatailor: true` setups continue to work and are guided toward `adTracking: AD_TRACKING.SSAI.MT` via the console warning