### PR TITLE
feat: support custom CDN / custom domain for MediaTailor SSAI and ad …

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,53 @@ if (shouldEnableTracking(currentUser.id)) {
 
 ## Configuration Options
 
+### Ad Tracking
+
+`config.ad.type` declares which ad category the tracker should wire up. **If not set, no ad tracking runs** — this is the safe default. Omitting it while passing other options triggers a console warning.
+
+#### CSAI — Client-Side Ad Insertion
+
+All CSAI frameworks (IMA, Brightcove IMA, Freewheel) share the `adsready` event path. The tracker auto-detects which one is present — no sub-type needed. Just declare `CSAI`.
+
+| Value    | Constant         | Behaviour                                                                  |
+| -------- | ---------------- | -------------------------------------------------------------------------- |
+| `'csai'` | `AD_TRACKING.CSAI` | Auto-detects: Brightcove IMA → IMA → Freewheel → generic fallback       |
+
+#### SSAI — Server-Side Ad Insertion
+
+Each SSAI platform has its own SDK and a completely different activation path — they cannot be auto-detected. **A sub-type is always required.**
+
+| Value        | Constant               | Behaviour                                                               |
+| ------------ | ---------------------- | ----------------------------------------------------------------------- |
+| `'ssai:dai'` | `AD_TRACKING.SSAI.DAI` | Google DAI (`google.ima.dai.api`)                                       |
+| `'ssai:mt'`  | `AD_TRACKING.SSAI.MT`  | AWS MediaTailor                                                         |
+
+```javascript
+import { AD_TRACKING } from '@newrelic/video-videojs';
+
+// CSAI — one value covers all client-side frameworks
+new VideojsTracker(player, { config: { ad: { type: AD_TRACKING.CSAI } } });
+
+// SSAI — sub-type always required
+new VideojsTracker(player, { config: { ad: { type: AD_TRACKING.SSAI.DAI } } });
+new VideojsTracker(player, { config: { ad: { type: AD_TRACKING.SSAI.MT } } });
+
+// SSAI.MT with custom CDN config
+new VideojsTracker(player, {
+  config: {
+    ad: {
+      type: AD_TRACKING.SSAI.MT,
+      segmentPrefix: '/my-cdn-path/',
+    },
+  },
+});
+
+// Change at runtime before first loadstart / adsready
+tracker.setAdTracking(AD_TRACKING.CSAI);
+```
+
+> **Extending later:** add a new key to `AD_TRACKING.SSAI` — validation derives from the object automatically. No other changes needed.
+
 ### QoE (Quality of Experience) Settings
 
 | Option              | Type    | Default | Description                                                                                                                                                                              |
@@ -378,6 +425,18 @@ tracker.setOptions({
 });
 ```
 
+#### `tracker.setAdTracking(type)`
+
+Change the ad tracking mode after the tracker is created. Must be called before the first `loadstart` or `adsready` event to take effect.
+
+```javascript
+import { AD_TRACKING } from '@newrelic/video-videojs';
+
+// Valid values: 'csai' | 'ssai:dai' | 'ssai:mt'
+tracker.setAdTracking(AD_TRACKING.CSAI);
+tracker.setAdTracking(AD_TRACKING.SSAI.MT);
+```
+
 ### Example: Complete Integration
 
 ```javascript
@@ -437,68 +496,51 @@ The tracker captures four distinct bitrate metrics providing complete quality an
 
 ## Ad Tracking Support
 
-The tracker provides comprehensive ad tracking capabilities:
-
 ### Supported Ad Technologies
 
-- **IMA (Interactive Media Ads)** - Google IMA SDK integration
-- **Freewheel** - Freewheel ad platform support
-- **SSAI (Server-Side Ad Insertion)** - Dynamic Ad Insertion (DAI) support
+| Category | Frameworks detected | Constant |
+|---|---|---|
+| CSAI | Google IMA, Brightcove IMA, Freewheel, generic | `AD_TRACKING.CSAI` |
+| SSAI | Google DAI | `AD_TRACKING.SSAI.DAI` |
+| SSAI | AWS MediaTailor | `AD_TRACKING.SSAI.MT` |
 
-### SSAI/DAI Integration
+See [Configuration Options → Ad Tracking](#ad-tracking) for full usage and examples.
 
-Server-Side Ad Insertion is supported with automatic tracker selection for supported integrations:
+### Google DAI Integration
 
 ```javascript
-// SSAI tracker selection is automatic for supported integrations
-const tracker = new VideojsTracker(player, options);
-
-// The tracker will automatically capture:
-// - Ad breaks, starts, and completions
-// - Ad quartiles and click events
-// - SSAI-specific metadata when available
+import { AD_TRACKING } from '@newrelic/video-videojs';
+const tracker = new VideojsTracker(player, { config: { ad: { type: AD_TRACKING.SSAI.DAI } } });
 ```
 
-**Example:** See [samples/dai/index.html](./samples/dai/index.html) for a complete SSAI implementation.
-
-> [!NOTE]
-> **Attention:**
-> This version supports tracking for SSAI (Server-Side Ad Insertion), including AWS MediaTailor. See [samples/media-tailor-lab.html](./samples/media-tailor-lab.html) and the [SSAI Guide](./docs/ssai.md).
+See [samples/dai/index.html](./samples/dai/index.html) for a complete example.
 
 ### AWS MediaTailor Integration
 
-The tracker automatically detects and tracks AWS MediaTailor SSAI streams. It supports:
-
-- **HLS and DASH** manifest formats
-- **VOD and LIVE** stream types
-- **Multiple ads (pods)** within a single break
-- **Quartile tracking** (25%, 50%, 75%)
-- **Tracking metadata enrichment** when MediaTailor tracking data is available
-
-#### Usage
+Supports HLS/DASH, VOD/LIVE, multiple ads per break, quartile tracking, and tracking metadata enrichment.
 
 ```javascript
-import VideojsTracker from '@newrelic/video-videojs';
+import { AD_TRACKING } from '@newrelic/video-videojs';
 
-// Initialize player with a sessionized MediaTailor playback URL
 player.src({
   src: 'https://your-mediatailor-endpoint.mediatailor.region.amazonaws.com/v1/master/...',
   type: 'application/x-mpegURL'
 });
 
-// Initialize tracker - MediaTailor support is automatic
-const tracker = new VideojsTracker(player, options);
+const tracker = new VideojsTracker(player, { config: { ad: { type: AD_TRACKING.SSAI.MT } } });
+
+// With custom CDN config
+const tracker = new VideojsTracker(player, {
+  config: {
+    ad: {
+      type: AD_TRACKING.SSAI.MT,
+      segmentPrefix: '/my-cdn-path/',
+    },
+  },
+});
 ```
 
-The tracker will automatically:
-1. Detect MediaTailor URLs (`.mediatailor.` in URL)
-2. Build the MediaTailor tracking endpoint from the sessionized playback URL
-3. Parse HLS or DASH manifests for ad markers
-4. Track ad breaks, ad starts, quartiles, and ad ends
-5. Enrich ad metadata with the MediaTailor tracking endpoint when available
-6. Handle VOD and LIVE streams appropriately
-
-MediaTailor-specific behavior is automatic. The customer does not need to pass MediaTailor-only configuration flags into the tracker.
+Works with default AWS hostnames and custom CDN domains. See [docs/ssai.md](./docs/ssai.md) for custom CDN setup and advanced options.
 
 ## SSAI Guide
 

--- a/docs/ssai.md
+++ b/docs/ssai.md
@@ -14,21 +14,57 @@ Customers should already have:
 - valid New Relic streaming credentials
 - a real SSAI playback URL from their ad stitching provider
 
-For AWS MediaTailor specifically, the tracker expects a sessionized playback URL. The MediaTailor path is selected when the source URL contains `.mediatailor.`.
+## Activation
+
+Set `config.ad.type` to `AD_TRACKING.SSAI.MT` to activate the MediaTailor tracker. SSAI platforms cannot be auto-detected — each one has its own SDK and activation path, so declaring the sub-type is always required.
+
+```javascript
+import { AD_TRACKING } from '@newrelic/video-videojs';
+
+const tracker = new VideojsTracker(player, {
+  config: { ad: { type: AD_TRACKING.SSAI.MT } },
+});
+```
+
+All MediaTailor-specific options live alongside `type` in `config.ad`. If you need custom CDN config:
+
+```javascript
+const tracker = new VideojsTracker(player, {
+  config: {
+    ad: {
+      type: AD_TRACKING.SSAI.MT,
+      segmentPrefix: '/your-path/',
+    },
+  },
+});
+```
 
 ## What The Tracker Does Automatically
 
 For MediaTailor streams, the tracker automatically:
 
-1. Detects that the playback URL is a MediaTailor source.
-2. Detects whether the manifest format is HLS or DASH.
-3. Detects whether playback is VOD or LIVE from player state.
-4. Builds the MediaTailor tracking endpoint from the playback URL when a session id is present.
-5. Parses manifests to discover ad breaks.
-6. Sends ad break, ad start, quartile, and ad end events.
-7. Enriches ad metadata with tracking endpoint data when that data is available.
+1. Detects whether the manifest format is HLS or DASH.
+2. Detects whether playback is VOD or LIVE from player state.
+3. Parses manifests to discover ad breaks and distinguish ad segments from content segments.
+4. Sends ad break, ad start, quartile, and ad end events.
+5. Enriches ad metadata when tracking data is available.
 
-Customers do not need to pass MediaTailor-specific tracker flags for manifest parsing or live polling behavior.
+## Custom CDN / Custom Domain
+
+If you have configured CDN segment prefixes in the AWS MediaTailor console, the tracker detects ad segments automatically using the AWS-recommended `/tm/` ad-segment path convention — no extra config needed.
+
+If your CDN ad-segment prefix uses a non-standard path (not `/tm/`), pass the path as an override:
+
+```javascript
+const tracker = new VideojsTracker(player, {
+  config: {
+    ad: {
+      type: AD_TRACKING.SSAI.MT,
+      segmentPrefix: '/your-path/',
+    },
+  },
+});
+```
 
 ## Supported MediaTailor Scenarios
 
@@ -65,17 +101,15 @@ Some metadata can arrive after playback has already started if it is filled in f
 ## Common Integration Requirements
 
 - The player source should be the actual stitched SSAI playback URL.
-- The MediaTailor URL should still contain the session identifier required to derive the tracking endpoint.
 - The player tech must be able to play the provided source format.
 
 ## Troubleshooting
 
-If MediaTailor tracking does not activate, customers should verify:
+If MediaTailor tracking does not activate, verify:
 
-1. the source really is a MediaTailor playback URL
-2. the source contains `.mediatailor.`
-3. the URL is sessionized and still contains the required session identifier
-4. the source MIME type passed to Video.js matches the actual manifest format
+1. `config.ad.type: AD_TRACKING.SSAI.MT` is set in the tracker options.
+2. Segment requests are reaching the player (check the Network tab).
+3. If using a custom CDN ad-segment path, verify `config.ad.segmentPrefix` matches the path configured in the AWS MediaTailor console.
 
 ## Samples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/video-videojs",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/video-videojs",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@newrelic/video-core": "^4.1.5"
@@ -6307,9 +6307,9 @@
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/samples/media-tailor-lab.html
+++ b/samples/media-tailor-lab.html
@@ -1,860 +1,587 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MediaTailor Lab</title>
-    <link href="https://vjs.zencdn.net/8.10.0/video-js.css" rel="stylesheet" />
-    <style>
-      :root {
-        --bg: #07131f;
-        --bg-accent: #0f2438;
-        --panel: rgba(9, 24, 39, 0.86);
-        --panel-strong: rgba(7, 18, 31, 0.96);
-        --border: rgba(168, 194, 215, 0.12);
-        --text: #edf5fc;
-        --muted: #8ca3ba;
-        --accent: #7de4c0;
-        --accent-warm: #ffd37f;
-      }
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MediaTailor Lab</title>
+  <link href="https://vjs.zencdn.net/8.10.0/video-js.css" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-      * {
-        box-sizing: border-box;
-      }
+    :root {
+      --bg:      #0b1520;
+      --surface: #111e2e;
+      --border:  rgba(255,255,255,0.08);
+      --text:    #e8f2fc;
+      --muted:   #7a96b0;
+      --accent:  #4dd9a8;
+      --danger:  #f07070;
+      --warn:    #f0b84d;
+    }
 
-      body {
-        margin: 0;
-        min-height: 100vh;
-        font-family: Georgia, 'Times New Roman', serif;
-        color: var(--text);
-        background:
-          radial-gradient(
-            circle at top,
-            rgba(125, 228, 192, 0.12),
-            transparent 30%
-          ),
-          linear-gradient(180deg, var(--bg-accent), var(--bg));
-      }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      min-height: 100vh;
+    }
 
-      .shell {
-        width: min(1280px, calc(100vw - 32px));
-        margin: 0 auto;
-        padding: 28px 0 40px;
-      }
+    /* ── Layout ───────────────────────────────────────────────── */
 
-      .hero {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: 20px;
-        margin-bottom: 22px;
-      }
+    .page {
+      max-width: 1320px;
+      margin: 0 auto;
+      padding: 20px 20px 40px;
+    }
 
-      .hero h1 {
-        margin: 0 0 10px;
-        font-size: clamp(2rem, 3vw, 3.2rem);
-        line-height: 1;
-      }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 18px;
+    }
 
-      .hero p,
-      .tiny,
-      .hint {
-        color: var(--muted);
-      }
+    header h1 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
 
-      .status-pill {
-        padding: 10px 14px;
-        border-radius: 999px;
-        border: 1px solid var(--border);
-        background: rgba(255, 255, 255, 0.06);
-        white-space: nowrap;
-      }
+    .status {
+      font-size: 0.78rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      padding: 4px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      color: var(--muted);
+    }
+    .status.playing { color: var(--accent); border-color: var(--accent); }
+    .status.error   { color: var(--danger); border-color: var(--danger); }
 
-      .workspace {
-        display: grid;
-        grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.9fr);
-        gap: 20px;
-      }
+    .workspace {
+      display: grid;
+      grid-template-columns: 1fr 300px;
+      gap: 16px;
+      align-items: start;
+    }
 
-      .panel {
-        border: 1px solid var(--border);
-        border-radius: 24px;
-        background: var(--panel);
-        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
-        backdrop-filter: blur(14px);
-      }
+    /* ── Player ───────────────────────────────────────────────── */
 
-      .stage,
-      .control-panel {
-        padding: 18px;
-      }
+    .player-wrap {
+      aspect-ratio: 16 / 9;
+      border-radius: 12px;
+      overflow: hidden;
+      background: #000;
+      border: 1px solid var(--border);
+    }
 
-      .control-panel {
-        background: linear-gradient(
-          180deg,
-          rgba(10, 26, 41, 0.96),
-          rgba(6, 16, 28, 0.98)
-        );
-      }
+    .player-wrap .video-js { width: 100%; height: 100%; }
 
-      .player-wrap {
-        position: relative;
-        aspect-ratio: 16 / 9;
-        width: 100%;
-        border-radius: 18px;
-        overflow: hidden;
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        background: rgba(0, 0, 0, 0.32);
-      }
+    /* ── Controls ─────────────────────────────────────────────── */
 
-      .player-wrap .video-js,
-      .player-wrap .vjs-tech,
-      .player-wrap .vjs-poster,
-      .player-wrap .vjs-control-bar {
-        width: 100%;
-      }
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
 
-      .player-wrap .video-js,
-      .player-wrap .vjs-tech,
-      .player-wrap .vjs-poster {
-        height: 100%;
-      }
+    .field label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 5px;
+    }
 
-      .player-wrap .video-js {
-        position: absolute;
-        inset: 0;
-      }
+    input[type="text"] {
+      width: 100%;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 9px 11px;
+      color: var(--text);
+      font: inherit;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    input[type="text"]:focus { border-color: var(--accent); }
+    input[type="text"]::placeholder { color: var(--muted); }
 
-      .meta-grid {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 12px;
-        margin-top: 14px;
-      }
+    .toggle-row {
+      display: flex;
+      gap: 6px;
+    }
 
-      .meta-card {
-        padding: 14px;
-        border-radius: 16px;
-        border: 1px solid rgba(255, 255, 255, 0.06);
-        background: rgba(255, 255, 255, 0.035);
-      }
+    .toggle {
+      flex: 1;
+      padding: 8px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--muted);
+      font: inherit;
+      font-size: 0.82rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.15s;
+      text-align: center;
+    }
+    .toggle.active {
+      background: rgba(77,217,168,0.12);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
 
-      .label {
-        display: block;
-        margin-bottom: 8px;
-        font-size: 0.82rem;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-        color: var(--muted);
-      }
+    .btn {
+      width: 100%;
+      padding: 10px;
+      border-radius: 8px;
+      border: none;
+      font: inherit;
+      font-size: 0.88rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+    .btn:hover { opacity: 0.88; }
+    .btn-primary {
+      background: var(--accent);
+      color: #07111b;
+    }
+    .btn-ghost {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      color: var(--muted);
+    }
 
-      .value {
-        font-size: 1rem;
-        line-height: 1.4;
-        word-break: break-word;
-      }
+    .session-status {
+      font-size: 0.75rem;
+      color: var(--muted);
+      min-height: 1.2em;
+    }
+    .session-status.ok  { color: var(--accent); }
+    .session-status.err { color: var(--danger); }
 
-      .log-panel {
-        margin-top: 14px;
-        padding: 0;
-        background: transparent;
-        border: 0;
-        box-shadow: none;
-      }
+    /* ── Log ──────────────────────────────────────────────────── */
 
-      .log-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 10px;
-        padding: 6px 0 14px;
-      }
+    .log-wrap {
+      margin-top: 16px;
+      grid-column: 1 / -1;
+    }
 
-      .log-header h2,
-      .group h2,
-      .group h3 {
-        margin: 0 0 8px;
-      }
+    .log-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
 
-      .log-output {
-        min-height: 280px;
-        max-height: 520px;
-        overflow-y: auto;
-        border-radius: 16px;
-        border: 1px solid rgba(255, 255, 255, 0.06);
-        background: rgba(3, 9, 16, 0.94);
-        padding: 14px;
-        font-family: 'SFMono-Regular', Consolas, monospace;
-        font-size: 12px;
-        line-height: 1.45;
-      }
+    .log-header span {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--muted);
+    }
 
-      .log-line {
-        padding: 5px 0;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-      }
+    .log-clear {
+      background: none;
+      border: none;
+      font: inherit;
+      font-size: 0.75rem;
+      color: var(--muted);
+      cursor: pointer;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .log-clear:hover { color: var(--text); }
 
-      .log-line:last-child {
-        border-bottom: 0;
-      }
+    .log {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 12px;
+      height: 220px;
+      overflow-y: auto;
+      font-family: 'SFMono-Regular', Menlo, Consolas, monospace;
+      font-size: 11.5px;
+      line-height: 1.55;
+      display: flex;
+      flex-direction: column-reverse;
+    }
 
-      .log-time {
-        color: var(--accent);
-        margin-right: 8px;
-      }
+    .log-line { padding: 2px 0; word-break: break-all; }
+    .log-time { color: #3a5570; margin-right: 6px; }
+    .log-tag-mt     { color: var(--accent);  margin-right: 6px; }
+    .log-tag-player { color: #7a96ff; margin-right: 6px; }
+    .log-tag-lab    { color: var(--warn); margin-right: 6px; }
+    .log-tag-err    { color: var(--danger); margin-right: 6px; }
 
-      .log-tag {
-        color: var(--accent-warm);
-        margin-right: 8px;
-      }
+    @media (max-width: 800px) {
+      .workspace { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+  <header>
+    <h1>MediaTailor Lab</h1>
+    <div class="status" id="status">Idle</div>
+  </header>
 
-      .control-top {
-        margin-bottom: 12px;
-      }
+  <div class="workspace">
 
-      .group {
-        margin-bottom: 14px;
-        padding: 14px;
-        border-radius: 16px;
-        border: 1px solid rgba(255, 255, 255, 0.06);
-        background: rgba(255, 255, 255, 0.035);
-      }
+    <!-- Player -->
+    <div class="player-wrap" id="playerMount"></div>
 
-      .preset-grid,
-      .button-row,
-      .field-grid {
-        display: grid;
-        gap: 10px;
-      }
+    <!-- Controls -->
+    <div class="controls">
 
-      .preset-grid,
-      .field-grid.two,
-      .button-row {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-
-      button,
-      input,
-      select,
-      textarea {
-        font: inherit;
-      }
-
-      button {
-        border: 0;
-        border-radius: 12px;
-        padding: 11px 14px;
-        cursor: pointer;
-        color: #07111b;
-        background: linear-gradient(135deg, var(--accent), #9be7ef);
-        font-weight: 600;
-        box-shadow: 0 12px 28px rgba(125, 228, 192, 0.18);
-        transition:
-          transform 120ms ease,
-          box-shadow 120ms ease;
-      }
-
-      button:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 16px 34px rgba(125, 228, 192, 0.22);
-      }
-
-      button.secondary {
-        color: var(--text);
-        background: rgba(255, 255, 255, 0.08);
-        box-shadow: none;
-      }
-
-      button.preset.active {
-        outline: 2px solid var(--accent);
-        outline-offset: 1px;
-      }
-
-      input,
-      select,
-      textarea {
-        width: 100%;
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        border-radius: 12px;
-        padding: 11px 12px;
-        color: var(--text);
-        background: rgba(4, 12, 21, 0.78);
-      }
-
-      textarea {
-        min-height: 120px;
-        resize: vertical;
-      }
-
-      .checkbox-row {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-      }
-
-      .checkbox-row input {
-        width: 18px;
-        height: 18px;
-      }
-
-      .note {
-        margin-top: 12px;
-        padding: 12px;
-        border-radius: 12px;
-        background: rgba(255, 211, 127, 0.08);
-        border: 1px solid rgba(255, 211, 127, 0.12);
-        color: #ffe7b3;
-      }
-
-      @media (max-width: 1080px) {
-        .workspace,
-        .meta-grid {
-          grid-template-columns: minmax(0, 1fr);
-        }
-      }
-
-      @media (max-width: 720px) {
-        .shell {
-          width: min(100vw - 20px, 100%);
-          padding: 18px 0 28px;
-        }
-
-        .hero {
-          flex-direction: column;
-          align-items: flex-start;
-        }
-
-        .preset-grid,
-        .field-grid.two,
-        .button-row {
-          grid-template-columns: minmax(0, 1fr);
-        }
-      }
-    </style>
-  </head>
-  <body>
-    <div class="shell">
-      <div class="hero">
-        <div>
-          <h1>MediaTailor Lab</h1>
-          <p>
-            Load a sessionized MediaTailor playback URL and switch between HLS
-            or DASH scenarios. New Relic credentials stay in code, while the
-            tracker uses guide-aligned MediaTailor defaults automatically.
-          </p>
-        </div>
-        <div id="statusPill" class="status-pill">Idle</div>
+      <div class="field">
+        <label>License Key</label>
+        <input type="text" id="licenseKey" placeholder="NRBR-…" spellcheck="false" />
       </div>
 
-      <div class="workspace">
-        <div class="panel stage">
-          <div class="player-wrap" id="playerMount"></div>
+      <div class="field">
+        <label>App ID</label>
+        <input type="text" id="appId" placeholder="1234567" spellcheck="false" />
+      </div>
 
-          <div class="meta-grid">
-            <div class="meta-card">
-              <span class="label">Active Source</span>
-              <div id="activeSource" class="value">No stream loaded</div>
-            </div>
-            <div class="meta-card">
-              <span class="label">Playback Mode</span>
-              <div id="activeMode" class="value">Unset</div>
-            </div>
-            <div class="meta-card">
-              <span class="label">Manifest Type</span>
-              <div id="activeFormat" class="value">Unset</div>
-            </div>
-          </div>
+      <div class="field">
+        <label>Playback URL</label>
+        <input type="text" id="urlInput" placeholder="/v1/session/… or /v1/master/…" spellcheck="false" />
+      </div>
 
-          <div class="log-panel">
-            <div class="log-header">
-              <div>
-                <h2>Event Log</h2>
-                <p class="tiny">
-                  Browser console entries tagged with `mt`, plus core Video.js
-                  lifecycle events.
-                </p>
-              </div>
-              <button id="clearLogButton" class="secondary" type="button">
-                Clear log
-              </button>
-            </div>
-            <div id="logOutput" class="log-output"></div>
-          </div>
-        </div>
-
-        <div class="panel control-panel">
-          <div class="control-top">
-            <h2>Controls</h2>
-            <p class="tiny">
-              The tracker auto-detects MediaTailor and determines VOD versus
-              live from playback. The mode selector here is only for repeatable
-              lab labeling.
-            </p>
-          </div>
-
-          <div class="group">
-            <h3>Scenario Presets</h3>
-            <div class="preset-grid">
-              <button
-                class="preset"
-                type="button"
-                data-format="hls"
-                data-mode="vod"
-              >
-                HLS VOD
-              </button>
-              <button
-                class="preset"
-                type="button"
-                data-format="hls"
-                data-mode="live"
-              >
-                HLS Live
-              </button>
-              <button
-                class="preset"
-                type="button"
-                data-format="dash"
-                data-mode="vod"
-              >
-                DASH VOD
-              </button>
-              <button
-                class="preset"
-                type="button"
-                data-format="dash"
-                data-mode="live"
-              >
-                DASH Live
-              </button>
-            </div>
-          </div>
-
-          <form id="controlForm">
-            <div class="group">
-              <h3>MediaTailor Stream</h3>
-              <div class="field-grid">
-                <div>
-                  <label class="label" for="sourceUrl">Playback URL</label>
-                  <textarea
-                    id="sourceUrl"
-                    name="sourceUrl"
-                    placeholder="Paste the sessionized MediaTailor playback URL here"
-                    spellcheck="false"
-                  ></textarea>
-                </div>
-                <div class="field-grid two">
-                  <div>
-                    <label class="label" for="format">Format</label>
-                    <select id="format" name="format">
-                      <option value="hls">HLS</option>
-                      <option value="dash">DASH</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label class="label" for="mode">Scenario</label>
-                    <select id="mode" name="mode">
-                      <option value="vod">VOD</option>
-                      <option value="live">Live</option>
-                    </select>
-                  </div>
-                </div>
-                <div>
-                  <label class="label" for="contentTitle">Content Title</label>
-                  <input
-                    id="contentTitle"
-                    name="contentTitle"
-                    type="text"
-                    placeholder="Optional contentTitle custom data"
-                  />
-                </div>
-              </div>
-              <div class="hint">
-                Use the actual MediaTailor playback endpoint here. The tracker
-                only activates when the source contains `.mediatailor.`.
-              </div>
-            </div>
-
-            <div class="group">
-              <h3>Playback Options</h3>
-              <div class="field-grid two">
-                <label class="checkbox-row" for="autoplay">
-                  <input id="autoplay" name="autoplay" type="checkbox" />
-                  <span>autoplay</span>
-                </label>
-              </div>
-              <div class="note">
-                Live tracking cadence follows the MediaTailor guide: target
-                duration for HLS, minimumUpdatePeriod for DASH, and one tracking
-                metadata fetch after the first playable manifest for VOD.
-              </div>
-            </div>
-
-            <div class="group">
-              <h3>Actions</h3>
-              <div class="button-row">
-                <button id="loadButton" type="submit">Load stream</button>
-                <button id="resetButton" class="secondary" type="button">
-                  Reset player
-                </button>
-              </div>
-            </div>
-          </form>
+      <div class="field">
+        <label>Format</label>
+        <div class="toggle-row">
+          <button class="toggle active" data-fmt="hls">HLS</button>
+          <button class="toggle" data-fmt="dash">DASH</button>
         </div>
       </div>
+
+      <div class="session-status" id="sessionStatus"></div>
+
+      <div class="field">
+        <label>NR Log Level</label>
+        <div class="toggle-row">
+          <button class="toggle active" data-level="error">Error</button>
+          <button class="toggle" data-level="warning">Warning</button>
+          <button class="toggle" data-level="debug">Debug</button>
+          <button class="toggle" data-level="all">All</button>
+        </div>
+      </div>
+
+      <button class="btn btn-primary" id="loadBtn">Load</button>
+      <button class="btn btn-ghost" id="resetBtn">Reset</button>
+
     </div>
 
-    <script src="https://vjs.zencdn.net/8.10.0/video.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/videojs-contrib-dash@4.1.0/dist/videojs-dash.min.js"></script>
-    <script src="../dist/umd/newrelic-video-videojs.min.js"></script>
-    <script>
-      const STORAGE_KEY = 'nr-videojs-media-tailor-lab';
-      const PLAYER_ID = 'media-tailor-player';
-      const PLAYER_EVENTS = [
-        'loadstart',
-        'loadedmetadata',
-        'loadeddata',
-        'play',
-        'playing',
-        'pause',
-        'waiting',
-        'seeking',
-        'seeked',
-        'timeupdate',
-        'ended',
-        'error',
-      ];
+    <!-- Log -->
+    <div class="log-wrap">
+      <div class="log-header">
+        <span>Event log</span>
+        <button class="log-clear" id="clearLog">Clear</button>
+      </div>
+      <div class="log" id="log"></div>
+    </div>
 
-      const NEW_RELIC_OPTIONS = {
-        info: {
-          beacon: 'YOUR_NEW_RELIC_BEACON',
-          licenseKey: 'YOUR_NEW_RELIC_LICENSE_KEY',
-          applicationID: 'YOUR_NEW_RELIC_APPLICATION_ID',
-        },
-        customData: {
-          labName: 'media-tailor-lab',
-          integration: 'videojs-mediatailor-sample',
-        },
-      };
+  </div>
+</div>
 
-      const form = document.getElementById('controlForm');
-      const sourceUrlField = document.getElementById('sourceUrl');
-      const formatField = document.getElementById('format');
-      const modeField = document.getElementById('mode');
-      const contentTitleField = document.getElementById('contentTitle');
-      const autoplayField = document.getElementById('autoplay');
-      const statusPill = document.getElementById('statusPill');
-      const activeSource = document.getElementById('activeSource');
-      const activeMode = document.getElementById('activeMode');
-      const activeFormat = document.getElementById('activeFormat');
-      const logOutput = document.getElementById('logOutput');
-      const playerMount = document.getElementById('playerMount');
-      const resetButton = document.getElementById('resetButton');
-      const clearLogButton = document.getElementById('clearLogButton');
-      const presetButtons = Array.from(document.querySelectorAll('.preset'));
+<script src="https://vjs.zencdn.net/8.10.0/video.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/videojs-contrib-dash@4.1.0/dist/videojs-dash.min.js"></script>
+<script src="../dist/umd/newrelic-video-videojs.min.js"></script>
+<script>
+  // ── New Relic credentials ────────────────────────────────────
+  // beacon is fixed; licenseKey + appId come from the input fields.
+  const NR_BEACON = 'bam.nr-data.net';
 
-      let player = null;
-      let tracker = null;
-      let consolePatched = false;
+  function getNrInfo() {
+    return {
+      beacon:        NR_BEACON,
+      licenseKey:    document.getElementById('licenseKey').value.trim(),
+      applicationID: document.getElementById('appId').value.trim(),
+    };
+  }
 
-      function appendLog(tag, message) {
-        const line = document.createElement('div');
-        line.className = 'log-line';
-        const time = new Date().toLocaleTimeString();
-        line.innerHTML =
-          '<span class="log-time">' +
-          time +
-          '</span>' +
-          '<span class="log-tag">[' +
-          tag +
-          ']</span>' +
-          '<span>' +
-          escapeHtml(message) +
-          '</span>';
-        logOutput.prepend(line);
+  // ── State ────────────────────────────────────────────────────
+  const STORAGE_KEY = 'nr-mt-lab-v1';
+  const PLAYER_ID   = 'mt-player';
+
+  let player   = null;
+  let tracker  = null;
+  let format   = 'hls';
+
+  // ── DOM refs ─────────────────────────────────────────────────
+  const urlInput     = document.getElementById('urlInput');
+  const loadBtn      = document.getElementById('loadBtn');
+  const resetBtn     = document.getElementById('resetBtn');
+  const sessionStatus = document.getElementById('sessionStatus');
+  const statusEl     = document.getElementById('status');
+  const logEl        = document.getElementById('log');
+  const clearLogBtn  = document.getElementById('clearLog');
+
+  // ── Format toggle ────────────────────────────────────────────
+  const fmtToggles = Array.from(document.querySelectorAll('[data-fmt]'));
+  fmtToggles.forEach(btn => {
+    btn.addEventListener('click', () => {
+      format = btn.dataset.fmt;
+      fmtToggles.forEach(b => b.classList.toggle('active', b === btn));
+      save();
+    });
+  });
+
+  // ── Log level toggle ─────────────────────────────────────────
+  const levelToggles = Array.from(document.querySelectorAll('[data-level]'));
+  levelToggles.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const L = VideojsTracker.Log.Levels;
+      const map = { error: L.ERROR, warning: L.WARNING, debug: L.DEBUG, all: L.ALL };
+      VideojsTracker.Log.level = map[btn.dataset.level];
+      levelToggles.forEach(b => b.classList.toggle('active', b === btn));
+      log('lab', 'NR log level → ' + btn.dataset.level.toUpperCase());
+    });
+  });
+
+  // ── Logging ──────────────────────────────────────────────────
+  function log(tag, msg) {
+    const line = document.createElement('div');
+    line.className = 'log-line';
+    const t = new Date().toLocaleTimeString('en', { hour12: false });
+    const tagClass = tag === 'mt' ? 'log-tag-mt'
+                   : tag === 'player' ? 'log-tag-player'
+                   : tag === 'err' ? 'log-tag-err'
+                   : 'log-tag-lab';
+    line.innerHTML = `<span class="log-time">${t}</span><span class="${tagClass}">[${tag}]</span>${esc(msg)}`;
+    logEl.prepend(line);
+  }
+
+  function esc(s) {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  // Intercept console so MT tracker output surfaces in the log
+  ['log','warn','error'].forEach(method => {
+    const orig = console[method].bind(console);
+    console[method] = function(...args) {
+      const msg = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
+      if (/\[MT|VideojsTracker/.test(msg)) log('mt', msg);
+      orig(...args);
+    };
+  });
+
+  clearLogBtn.addEventListener('click', () => { logEl.innerHTML = ''; });
+
+  // ── Status ───────────────────────────────────────────────────
+  function setStatus(label, type) {
+    statusEl.textContent = label;
+    statusEl.className = 'status' + (type ? ' ' + type : '');
+  }
+
+  // ── Persistence ──────────────────────────────────────────────
+  function save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      url:        urlInput.value,
+      format,
+      licenseKey: document.getElementById('licenseKey').value,
+      appId:      document.getElementById('appId').value,
+    }));
+  }
+
+  function restore() {
+    try {
+      const s = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      if (s.url)        urlInput.value = s.url;
+      if (s.licenseKey) document.getElementById('licenseKey').value = s.licenseKey;
+      if (s.appId)      document.getElementById('appId').value = s.appId;
+      if (s.format) {
+        format = s.format;
+        fmtToggles.forEach(b => b.classList.toggle('active', b.dataset.fmt === format));
       }
+    } catch (_) {}
+  }
 
-      function escapeHtml(value) {
-        return String(value)
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&#39;');
-      }
+  urlInput.addEventListener('input', save);
+  document.getElementById('licenseKey').addEventListener('input', save);
+  document.getElementById('appId').addEventListener('input', save);
 
-      function setStatus(label) {
-        statusPill.textContent = label;
-      }
+  // ── Player ───────────────────────────────────────────────────
+  function mountPlayer() {
+    document.getElementById('playerMount').innerHTML =
+      `<video id="${PLAYER_ID}" class="video-js vjs-default-skin" controls playsinline preload="auto"></video>`;
+  }
 
-      function updateActiveSummary(state) {
-        activeSource.textContent = state.sourceUrl || 'No stream loaded';
-        activeMode.textContent = state.mode
-          ? state.mode.toUpperCase()
-          : 'Unset';
-        activeFormat.textContent = state.format
-          ? state.format.toUpperCase()
-          : 'Unset';
-      }
+  function disposePlayer() {
+    if (player && !player.isDisposed()) player.dispose();
+    player = null;
+    tracker = null;
+    mountPlayer();
+  }
 
-      function setPreset(format, mode) {
-        formatField.value = format;
-        modeField.value = mode;
-        presetButtons.forEach((button) => {
-          const isActive =
-            button.dataset.format === format && button.dataset.mode === mode;
-          button.classList.toggle('active', isActive);
-        });
-      }
-
-      function readState() {
-        return {
-          sourceUrl: sourceUrlField.value.trim(),
-          format: formatField.value,
-          mode: modeField.value,
-          contentTitle: contentTitleField.value.trim(),
-          autoplay: autoplayField.checked,
-        };
-      }
-
-      function writeState(state) {
-        sourceUrlField.value = state.sourceUrl || '';
-        formatField.value = state.format || 'hls';
-        modeField.value = state.mode || 'vod';
-        contentTitleField.value = state.contentTitle || '';
-        autoplayField.checked = Boolean(state.autoplay);
-        setPreset(formatField.value, modeField.value);
-        updateActiveSummary(state);
-      }
-
-      function persistState() {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(readState()));
-      }
-
-      function loadStoredState() {
-        try {
-          const raw = localStorage.getItem(STORAGE_KEY);
-          return raw ? JSON.parse(raw) : null;
-        } catch (error) {
-          appendLog('lab', 'Failed to restore saved state: ' + error.message);
-          return null;
+  function attachEvents(p) {
+    const events = ['loadstart','loadedmetadata','play','playing','pause','waiting','seeking','seeked','ended','error'];
+    events.forEach(ev => {
+      p.on(ev, () => {
+        if (ev === 'error') {
+          const e = p.error();
+          log('err', ev + ': ' + (e?.message || 'unknown'));
+          setStatus('Error', 'error');
+        } else {
+          log('player', ev);
+          if (ev === 'playing') setStatus('Playing', 'playing');
+          else if (ev === 'ended') setStatus('Ended');
+          else if (ev === 'waiting') setStatus('Buffering');
         }
-      }
-
-      function patchConsole() {
-        if (consolePatched) {
-          return;
-        }
-
-        consolePatched = true;
-        ['log', 'warn', 'error'].forEach((method) => {
-          const original = console[method].bind(console);
-          console[method] = function () {
-            const args = Array.from(arguments);
-            const message = args
-              .map((part) => {
-                if (typeof part === 'string') {
-                  return part;
-                }
-                try {
-                  return JSON.stringify(part);
-                } catch (error) {
-                  return String(part);
-                }
-              })
-              .join(' ');
-
-            if (message.includes('[MT') || message.includes('VideojsTracker')) {
-              appendLog('mt', message);
-            }
-
-            original.apply(console, args);
-          };
-        });
-      }
-
-      function createPlayerElement() {
-        playerMount.innerHTML =
-          '<video id="' +
-          PLAYER_ID +
-          '" class="video-js vjs-default-skin" controls playsinline preload="auto"></video>';
-      }
-
-      function disposePlayer() {
-        if (player && !player.isDisposed()) {
-          player.dispose();
-        }
-
-        player = null;
-        tracker = null;
-        createPlayerElement();
-      }
-
-      function getSourceType(format) {
-        return format === 'dash'
-          ? 'application/dash+xml'
-          : 'application/x-mpegURL';
-      }
-
-      function buildTrackerOptions(state) {
-        const options = {
-          info: { ...NEW_RELIC_OPTIONS.info },
-          customData: {
-            ...NEW_RELIC_OPTIONS.customData,
-            streamScenario: state.mode,
-            streamFormat: state.format,
-          },
-        };
-
-        if (state.contentTitle) {
-          options.customData.contentTitle = state.contentTitle;
-        }
-
-        return options;
-      }
-
-      function attachPlayerLogging(instance) {
-        PLAYER_EVENTS.forEach((eventName) => {
-          if (eventName === 'timeupdate') {
-            return;
-          }
-
-          instance.on(eventName, () => {
-            if (eventName === 'error' && instance.error()) {
-              const error = instance.error();
-              appendLog(
-                'player',
-                eventName + ': ' + (error.message || 'Unknown player error'),
-              );
-              setStatus('Player error');
-              return;
-            }
-
-            appendLog('player', eventName);
-
-            if (eventName === 'playing') {
-              setStatus('Playing');
-            } else if (eventName === 'waiting') {
-              setStatus('Buffering');
-            } else if (eventName === 'ended') {
-              setStatus('Ended');
-            }
-          });
-        });
-      }
-
-      function loadStream(state) {
-        if (!state.sourceUrl) {
-          appendLog('lab', 'Playback URL is required.');
-          setStatus('Missing URL');
-          return;
-        }
-
-        if (!state.sourceUrl.includes('.mediatailor.')) {
-          appendLog(
-            'lab',
-            'Source does not look like a MediaTailor URL. The MediaTailor tracker will not activate.',
-          );
-        }
-
-        persistState();
-        updateActiveSummary(state);
-        setStatus('Loading');
-        appendLog(
-          'lab',
-          'Loading ' +
-            state.format.toUpperCase() +
-            ' ' +
-            state.mode.toUpperCase() +
-            ' stream',
-        );
-
-        disposePlayer();
-
-        player = videojs(PLAYER_ID, {
-          autoplay: state.autoplay,
-          controls: true,
-          fill: true,
-          responsive: false,
-          fluid: false,
-          html5: {
-            vhs: {
-              overrideNative: true,
-            },
-          },
-        });
-
-        player.version = videojs.VERSION;
-        attachPlayerLogging(player);
-
-        const trackerOptions = buildTrackerOptions(state);
-        tracker = new VideojsTracker(player, trackerOptions);
-
-        appendLog(
-          'lab',
-          'Tracker initialized with guide-aligned MediaTailor defaults',
-        );
-
-        player.ready(() => {
-          player.src({
-            src: state.sourceUrl,
-            type: getSourceType(state.format),
-          });
-
-          if (state.autoplay) {
-            player.play().catch((error) => {
-              appendLog('lab', 'Autoplay was blocked: ' + error.message);
-              setStatus('Ready');
-            });
-          } else {
-            setStatus('Ready');
-          }
-        });
-      }
-
-      presetButtons.forEach((button) => {
-        button.addEventListener('click', () => {
-          setPreset(button.dataset.format, button.dataset.mode);
-          updateActiveSummary(readState());
-          persistState();
-        });
       });
+    });
+  }
 
-      form.addEventListener('submit', (event) => {
-        event.preventDefault();
-        loadStream(readState());
-      });
+  // ── Mode detection ───────────────────────────────────────────
+  // Returns a summary object describing how the tracker will be configured
+  // based on the URL and what came back from session init.
+  function detectMode(raw, playbackUrl, trackingUrl) {
+    const isSession   = raw.includes('/v1/session/');
+    const isDirect    = raw.includes('/v1/master/') || raw.includes('/v1/dash/');
+    const isAwsDomain = /\.mediatailor\.[a-z0-9-]+\.amazonaws\.com/.test(raw);
+    const isCustomCdn = !isAwsDomain;
 
-      [
-        sourceUrlField,
-        formatField,
-        modeField,
-        contentTitleField,
-        autoplayField,
-      ].forEach((element) => {
-        element.addEventListener('change', () => {
-          const state = readState();
-          setPreset(state.format, state.mode);
-          updateActiveSummary(state);
-          persistState();
+    let mode, notes = [];
+
+    if (isSession && isAwsDomain) {
+      mode = 'AWS default — explicit session init';
+    } else if (isSession && isCustomCdn) {
+      mode = 'Custom CDN — explicit session init';
+    } else if (isDirect && isAwsDomain) {
+      mode = 'AWS default — direct playback URL';
+    } else if (isDirect && isCustomCdn) {
+      mode = 'Custom CDN — direct playback URL';
+    } else {
+      mode = isCustomCdn ? 'Custom CDN — unrecognised URL pattern' : 'AWS — unrecognised URL pattern';
+    }
+
+    if (trackingUrl)  notes.push('trackingUrl set (explicit)');
+    if (!trackingUrl) notes.push('trackingUrl not set (tracker will derive it)');
+
+    return { mode, notes };
+  }
+
+  // ── Load ─────────────────────────────────────────────────────
+  async function load() {
+    const raw = urlInput.value.trim();
+    if (!raw) { sessionStatus.textContent = 'Enter a URL first.'; return; }
+
+    sessionStatus.className = 'session-status';
+    sessionStatus.textContent = '';
+
+    let playbackUrl = raw;
+    let trackingUrl = null;
+
+    // If it's a session URL, POST to initialize and get the manifest URL back
+    if (raw.includes('/v1/session/')) {
+      const suffix  = format === 'dash' ? 'index.mpd' : 'master.m3u8';
+      const postUrl = raw.replace(/\/$/, '') + '/' + suffix;
+      const origin  = new URL(raw).origin;
+
+      sessionStatus.textContent = 'Initializing session…';
+      setStatus('Initializing');
+      log('lab', 'POST ' + postUrl);
+
+      try {
+        const res = await fetch(postUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
         });
-      });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        if (!data.manifestUrl) throw new Error('No manifestUrl in response');
 
-      resetButton.addEventListener('click', () => {
-        disposePlayer();
-        setStatus('Idle');
-        appendLog('lab', 'Player reset');
-        updateActiveSummary({});
-      });
+        playbackUrl = data.manifestUrl.startsWith('http')
+          ? data.manifestUrl
+          : origin + data.manifestUrl;
 
-      clearLogButton.addEventListener('click', () => {
-        logOutput.innerHTML = '';
-      });
+        if (data.trackingUrl) {
+          trackingUrl = data.trackingUrl.startsWith('http')
+            ? data.trackingUrl
+            : origin + data.trackingUrl;
+        }
 
-      patchConsole();
-      createPlayerElement();
-      writeState(loadStoredState() || {});
-      appendLog('lab', 'Lab ready');
-    </script>
-  </body>
+        sessionStatus.className = 'session-status ok';
+        sessionStatus.textContent = '✓ Session ready';
+        log('lab', 'manifest: ' + playbackUrl);
+        if (trackingUrl) log('lab', 'tracking: ' + trackingUrl);
+      } catch (err) {
+        sessionStatus.className = 'session-status err';
+        sessionStatus.textContent = '✗ ' + err.message;
+        log('err', 'Session init failed: ' + err.message);
+        setStatus('Error', 'error');
+        return;
+      }
+    }
+
+    // Build tracker options
+    const adConfig = { type: VideojsTracker.AD_TRACKING.SSAI.MT };
+    if (trackingUrl) adConfig.trackingUrl = trackingUrl;
+
+    // Debug: log detected mode before player is created
+    const { mode, notes } = detectMode(raw, playbackUrl, trackingUrl);
+    log('lab', '── tracker mode: ' + mode);
+    notes.forEach(n => log('lab', '   · ' + n));
+
+    disposePlayer();
+    setStatus('Loading');
+    log('lab', 'Loading ' + format.toUpperCase() + ' — ' + playbackUrl);
+
+    player = videojs(PLAYER_ID, {
+      controls: true,
+      fill: true,
+      muted: true,
+      html5: { vhs: { overrideNative: true } },
+    });
+    player.version = videojs.VERSION;
+    attachEvents(player);
+
+    const nrInfo = getNrInfo();
+    if (!nrInfo.licenseKey || !nrInfo.applicationID) {
+      log('lab', '⚠ No NR credentials — tracker will run but data will not be sent');
+    }
+
+    tracker = new VideojsTracker(player, {
+      config: { ad: adConfig },
+      info: nrInfo,
+    });
+
+    player.ready(() => {
+      player.src({
+        src: playbackUrl,
+        type: format === 'dash' ? 'application/dash+xml' : 'application/x-mpegURL',
+      });
+      player.play().catch(() => {});
+    });
+  }
+
+  // ── Wire up ──────────────────────────────────────────────────
+  loadBtn.addEventListener('click', load);
+  urlInput.addEventListener('keydown', e => { if (e.key === 'Enter') load(); });
+
+  resetBtn.addEventListener('click', () => {
+    disposePlayer();
+    sessionStatus.textContent = '';
+    setStatus('Idle');
+    log('lab', 'Reset');
+  });
+
+  // ── Boot ─────────────────────────────────────────────────────
+  restore();
+  mountPlayer();
+  log('lab', 'Ready');
+</script>
+</body>
 </html>

--- a/src/ads/media-tailor.js
+++ b/src/ads/media-tailor.js
@@ -23,6 +23,7 @@ import {
   parseHlsManifestForAdBreaks,
   parseDashManifestForAdBreaks,
   detectAdBreaksFromVhsPlaylist,
+  whichAdSegmentMarker,
   enrichAdScheduleWithTrackingMetadata,
   extractHlsTargetDurationSeconds,
   extractDashMinimumUpdatePeriodSeconds,
@@ -51,12 +52,10 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
   /**
    * Checks if tracker should be used for this player source
    */
-  static isUsing(player) {
-    return (
-      player &&
-      typeof player.currentSrc === 'function' &&
-      player.currentSrc().includes(MEDIATAILOR_HOST_MARKER)
-    );
+  static isUsing(player, options = {}) {
+    // Opt-in flag is the single source of truth.
+    // Accepts { mediatailor: true } or { mediatailor: { trackingUrl, adSegmentPrefix } }.
+    return Boolean(options && options.mediatailor);
   }
 
   /**
@@ -87,10 +86,31 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
   constructor(player, options = {}) {
     super(player);
 
+    // Normalize mediatailor option: true | { trackingUrl, adSegmentPrefix } | undefined
+    const mtOptions =
+      options.mediatailor === true ? {} : options.mediatailor || {};
+
     // Initialize state
     this.streamType = null; // 'vod' or 'live'
     this.manifestFormat = null; // 'hls' or 'dash'
     this.playbackManifestUrl = player.currentSrc();
+
+    // trackingUrl: optional override for the MediaTailor tracking endpoint.
+    // When not provided, the tracker derives it automatically from the playback URL.
+    this.explicitTrackingUrl = mtOptions.trackingUrl || null;
+
+    // adSegmentPrefix: only needed when the customer configured a CDN ad-segment
+    // prefix in AWS MediaTailor that does NOT follow the AWS-recommended /tm/ path.
+    // Most setups (default AWS hostname or CDN following AWS conventions) are
+    // detected automatically via MT_DEFAULT_AD_SEGMENT_PATH ('/tm/') and do not
+    // need this override.
+    this.adSegmentPrefix = mtOptions.adSegmentPrefix || null;
+
+    if (this.adSegmentPrefix) {
+      Log.debug(`[MT] ad segment detection: custom prefix "${this.adSegmentPrefix}"`);
+    } else {
+      Log.debug('[MT] ad segment detection: default (segments.mediatailor hostname or /tm/ path)');
+    }
 
     // Ad tracking state
     this.adSchedule = [];
@@ -120,19 +140,19 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     this.mediaPlaylistUrl = null;
     this.lastMediaPlaylistText = null;
 
-    console.log(`[MT - ${getTimestamp()}] MediaTailorAdsTracker initialized`, {
+    Log.debug(`[MT - ${getTimestamp()}] MediaTailorAdsTracker initialized`, {
       endpoint: this.playbackManifestUrl,
       trackingAPITimeout: TRACKING_API_TIMEOUT_MS,
     });
 
     this.manifestFormat = detectManifestFormatFromUrl(this.playbackManifestUrl);
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Manifest type: ${this.manifestFormat.toUpperCase()}`,
     );
 
     this.player.one('loadedmetadata', () => {
       this.streamType = detectPlaybackStreamType(this.player.duration());
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Stream type: ${this.streamType.toUpperCase()}`,
       );
       this.initializeTracking();
@@ -143,20 +163,22 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    * Initializes tracking based on detected stream type
    */
   initializeTracking() {
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Initializing ${this.manifestFormat.toUpperCase()} ${this.streamType.toUpperCase()} tracking`,
     );
 
-    // Extract tracking URL from sessionized URL
-    this.trackingEndpointUrl = buildTrackingEndpointUrl(this.playbackManifestUrl);
+    // Prefer explicit tracking URL (explicit POST session) over derived one
+    this.trackingEndpointUrl =
+      this.explicitTrackingUrl ||
+      buildTrackingEndpointUrl(this.playbackManifestUrl);
     if (this.trackingEndpointUrl) {
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Tracking URL extracted:`,
         this.trackingEndpointUrl,
       );
     } else {
-      console.warn(
-        `[MT - ${getTimestamp()}] No sessionId found - user must initialize session externally`,
+      Log.warn(
+        `[MT - ${getTimestamp()}] Could not derive tracking URL from playback URL — pass trackingUrl in mediatailor options if needed`,
       );
     }
 
@@ -191,7 +213,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     this.player.on('waiting', this.onWaiting);
     this.player.on('ended', this.onEnded);
     this.player.on('timeupdate', this.onTimeUpdate);
-    console.log(`[MT - ${getTimestamp()}] Event listeners registered`);
+    Log.debug(`[MT - ${getTimestamp()}] Event listeners registered`);
   }
 
   /**
@@ -228,7 +250,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    * Sets up VOD tracking (single parse, no polling)
    */
   setupVODTracking() {
-    console.log(`[MT - ${getTimestamp()}] VOD mode: Single manifest parse`);
+    Log.debug(`[MT - ${getTimestamp()}] VOD mode: Single manifest parse`);
     this.hookPlayerManifest();
   }
 
@@ -236,7 +258,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    * Sets up Live tracking (continuous polling)
    */
   setupLiveTracking() {
-    console.log(`[MT - ${getTimestamp()}] Live mode: Continuous polling`);
+    Log.debug(`[MT - ${getTimestamp()}] Live mode: Continuous polling`);
     this.hookPlayerManifest();
 
     const pollingInterval = this.getLiveRefreshIntervalMs();
@@ -250,7 +272,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       this.getAndProcessTrackingMetadata();
     }, pollingInterval);
 
-    console.log(`[MT - ${getTimestamp()}] Live polling started`, {
+    Log.debug(`[MT - ${getTimestamp()}] Live polling started`, {
       pollingInterval,
     });
   }
@@ -271,7 +293,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     if (!this.liveRefreshIntervalSeconds) return;
 
     const newInterval = this.getLiveRefreshIntervalMs();
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Updating live polling interval: ${this.liveRefreshIntervalSeconds}s`,
     );
 
@@ -295,7 +317,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
   hookPlayerManifest() {
     const tech = this.player.tech({ IWillNotUseThisInPlugins: true });
     if (!tech) {
-      console.log(`[MT - ${getTimestamp()}] No tech - using fallback fetch`);
+      Log.debug(`[MT - ${getTimestamp()}] No tech - using fallback fetch`);
       this.getManifestDirectly();
       return;
     }
@@ -316,7 +338,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     }
 
     // Fallback: Direct manifest fetch
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Using fallback: direct manifest fetch`,
     );
     this.getManifestDirectly();
@@ -328,7 +350,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
   hookHLSViaVHS(tech) {
     if (!tech.vhs || !tech.vhs.playlists) return false;
 
-    console.log(`[MT - ${getTimestamp()}] Hooked: VHS`);
+    Log.debug(`[MT - ${getTimestamp()}] Hooked: VHS`);
 
     // Parse already-loaded playlist
     const currentPlaylist = tech.vhs.playlists.media();
@@ -337,7 +359,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       currentPlaylist.segments &&
       currentPlaylist.segments.length > 0
     ) {
-      console.log(`[MT - ${getTimestamp()}] Parsing existing playlist`);
+      Log.debug(`[MT - ${getTimestamp()}] Parsing existing playlist`);
       this.parseVhsPlaylistForAdBreaks(currentPlaylist);
     }
 
@@ -362,7 +384,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       tech.el_.canPlayType &&
       tech.el_.canPlayType(HLS_MIME_TYPE)
     ) {
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Native HLS detected - using fallback`,
       );
       this.getManifestDirectly();
@@ -377,7 +399,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
   hookHLSViaContribHls(tech) {
     if (!tech.hls || !tech.hls.playlists) return false;
 
-    console.log(`[MT - ${getTimestamp()}] Hooked: contrib-hls (legacy)`);
+    Log.debug(`[MT - ${getTimestamp()}] Hooked: contrib-hls (legacy)`);
 
     // Parse already-loaded playlist
     const currentPlaylist = tech.hls.playlists.media();
@@ -406,7 +428,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
   hookDASHViaShaka(tech) {
     if (!tech.shakaPlayer) return false;
 
-    console.log(`[MT - ${getTimestamp()}] Hooked: Shaka Player`);
+    Log.debug(`[MT - ${getTimestamp()}] Hooked: Shaka Player`);
     tech.shakaPlayer.addEventListener('emsg', (event) => {
       this.handleDASHEmsgEvent(event);
     });
@@ -420,7 +442,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
   hookDASHViaDashJs(tech) {
     if (!tech.dash || !tech.dash.on) return false;
 
-    console.log(`[MT - ${getTimestamp()}] Hooked: dash.js`);
+    Log.debug(`[MT - ${getTimestamp()}] Hooked: dash.js`);
     tech.dash.on('EVENT_MODE_ON_RECEIVE', (event) => {
       this.handleDASHEventStream(event);
     });
@@ -432,7 +454,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    * Fetches manifest directly (fallback when hooks unavailable)
    */
   async getManifestDirectly() {
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Fallback: fetching manifest directly`,
     );
 
@@ -445,7 +467,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
         await this.fetchAndParseDashManifest(manifestUrl);
       }
     } catch (error) {
-      console.log(`[MT - ${getTimestamp()}] Fallback fetch error:`, error);
+      Log.debug(`[MT - ${getTimestamp()}] Fallback fetch error:`, error);
     }
   }
 
@@ -454,17 +476,17 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    */
   async fetchAndParseHlsManifest(manifestUrl) {
     try {
-      console.log(`[MT - ${getTimestamp()}] Fetching HLS master manifest`);
+      Log.debug(`[MT - ${getTimestamp()}] Fetching HLS master manifest`);
 
       // Fetch master manifest
       const { mediaPlaylistUrl } = await fetchHlsMasterManifest(manifestUrl);
 
       if (!mediaPlaylistUrl) {
-        console.log(`[MT - ${getTimestamp()}] No media playlist found`);
+        Log.debug(`[MT - ${getTimestamp()}] No media playlist found`);
         return;
       }
 
-      console.log(`[MT - ${getTimestamp()}] Fetching media playlist`);
+      Log.debug(`[MT - ${getTimestamp()}] Fetching media playlist`);
 
       // Fetch media playlist
       const mediaText = await fetchHlsMediaPlaylist(mediaPlaylistUrl);
@@ -478,13 +500,13 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       // Parse for ads
       const ads = parseHlsManifestForAdBreaks(mediaText);
       if (ads.length > 0) {
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Detected ${ads.length} ad break(s)`,
         );
         this.mergeNewAds(ads);
       }
     } catch (error) {
-      console.log(`[MT - ${getTimestamp()}] HLS fetch error:`, error);
+      Log.debug(`[MT - ${getTimestamp()}] HLS fetch error:`, error);
     }
   }
 
@@ -493,7 +515,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    */
   async fetchAndParseDashManifest(manifestUrl) {
     try {
-      console.log(`[MT - ${getTimestamp()}] Fetching DASH manifest`);
+      Log.debug(`[MT - ${getTimestamp()}] Fetching DASH manifest`);
 
       // Fetch DASH manifest
       const xmlText = await fetchDashManifest(manifestUrl);
@@ -508,7 +530,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       // Parse for ads
       const ads = parseDashManifestForAdBreaks(xmlText);
 
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] DASH: ${ads.length} ad break(s) found`,
       );
 
@@ -520,14 +542,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
         !this.hasAttemptedTrackingFetch
       ) {
         // No SCTE-35 markers in manifest - fall back to tracking API directly
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] DASH: no manifest cues, fetching tracking API`,
         );
         this.hasAttemptedTrackingFetch = true;
         this.getAndProcessTrackingMetadata();
       }
     } catch (error) {
-      console.log(`[MT - ${getTimestamp()}] DASH fetch error:`, error);
+      Log.debug(`[MT - ${getTimestamp()}] DASH fetch error:`, error);
     }
   }
 
@@ -535,14 +557,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    * Handles DASH emsg events from Shaka Player
    */
   handleDASHEmsgEvent(event) {
-    console.log(`[MT - ${getTimestamp()}] DASH emsg event:`, event);
+    Log.debug(`[MT - ${getTimestamp()}] DASH emsg event:`, event);
 
     try {
       // Shaka Player emits emsg events with event.detail containing the emsg box data
       const emsgData = event.detail;
 
       if (!emsgData) {
-        console.log(`[MT - ${getTimestamp()}] No emsg data in event`);
+        Log.debug(`[MT - ${getTimestamp()}] No emsg data in event`);
         return;
       }
 
@@ -551,14 +573,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       const schemeIdUri = emsgData.schemeIdUri || '';
 
       if (!schemeIdUri.includes(SCTE35_SCHEME_MARKER)) {
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Non-SCTE-35 emsg, skipping:`,
           schemeIdUri,
         );
         return;
       }
 
-      console.log(`[MT - ${getTimestamp()}] SCTE-35 emsg detected:`, {
+      Log.debug(`[MT - ${getTimestamp()}] SCTE-35 emsg detected:`, {
         schemeIdUri: emsgData.schemeIdUri,
         value: emsgData.value,
         timescale: emsgData.timescale,
@@ -592,14 +614,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
           pods: [],
         };
 
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Adding ad break from DASH emsg:`,
           adBreak,
         );
         this.mergeNewAds([adBreak]);
       }
     } catch (error) {
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Error parsing DASH emsg event:`,
         error,
       );
@@ -610,14 +632,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    * Handles DASH event stream from dash.js
    */
   handleDASHEventStream(event) {
-    console.log(`[MT - ${getTimestamp()}] DASH event stream:`, event);
+    Log.debug(`[MT - ${getTimestamp()}] DASH event stream:`, event);
 
     try {
       // dash.js emits events with different structure
       const eventData = event.event || event;
 
       if (!eventData) {
-        console.log(`[MT - ${getTimestamp()}] No event data`);
+        Log.debug(`[MT - ${getTimestamp()}] No event data`);
         return;
       }
 
@@ -625,14 +647,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       const schemeIdUri = eventData.schemeIdUri || '';
 
       if (!schemeIdUri.includes(SCTE35_SCHEME_MARKER)) {
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Non-SCTE-35 event, skipping:`,
           schemeIdUri,
         );
         return;
       }
 
-      console.log(`[MT - ${getTimestamp()}] SCTE-35 event stream detected:`, {
+      Log.debug(`[MT - ${getTimestamp()}] SCTE-35 event stream detected:`, {
         id: eventData.id,
         schemeIdUri: eventData.schemeIdUri,
         presentationTime: eventData.presentationTime,
@@ -658,14 +680,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
           pods: [],
         };
 
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Adding ad break from DASH event stream:`,
           adBreak,
         );
         this.mergeNewAds([adBreak]);
       }
     } catch (error) {
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Error parsing DASH event stream:`,
         error,
       );
@@ -676,14 +698,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    * Parses VHS playlist object for ads
    */
   parseVhsPlaylistForAdBreaks(playlist) {
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Parsing VHS playlist (${
         playlist.segments?.length || 0
       } segments)`,
     );
 
     if (!playlist.segments || playlist.segments.length === 0) {
-      console.log(`[MT - ${getTimestamp()}] No segments in playlist`);
+      Log.debug(`[MT - ${getTimestamp()}] No segments in playlist`);
       return;
     }
 
@@ -693,10 +715,23 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     );
 
     // VHS strips CUE tags - detect via discontinuityStarts + MediaTailor segments
-    const ads = detectAdBreaksFromVhsPlaylist(playlist);
+    const ads = detectAdBreaksFromVhsPlaylist(playlist, {
+      adSegmentPrefix: this.adSegmentPrefix,
+    });
 
     if (ads.length > 0) {
-      console.log(
+      // Log which detection path matched — only on first detection to avoid noise
+      if (!this._detectionPathLogged) {
+        const firstSeg = playlist.segments && playlist.segments.find(s =>
+          whichAdSegmentMarker(s, { adSegmentPrefix: this.adSegmentPrefix })
+        );
+        if (firstSeg) {
+          const path = whichAdSegmentMarker(firstSeg, { adSegmentPrefix: this.adSegmentPrefix });
+          Log.debug(`[MT] ad segment detection matched via: ${path}`);
+          this._detectionPathLogged = true;
+        }
+      }
+      Log.debug(
         `[MT - ${getTimestamp()}] VHS detected ${ads.length} ad break(s), ${ads.reduce(
           (sum, ab) => sum + ab.pods.length,
           0,
@@ -704,7 +739,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       );
       this.mergeNewAds(ads);
     } else {
-      console.log(`[MT - ${getTimestamp()}] No ads detected in VHS playlist`);
+      Log.debug(`[MT - ${getTimestamp()}] No ads detected in VHS playlist`);
     }
   }
 
@@ -716,7 +751,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     if (this.streamType !== STREAM_TYPE.LIVE) return;
 
     if (this.isFetchingManifest) {
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Manifest fetch already in progress, skipping`,
       );
       return;
@@ -735,7 +770,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
         await this.fetchAndParseDashManifest(this.playbackManifestUrl);
       }
     } catch (error) {
-      console.log(`[MT - ${getTimestamp()}] Manifest poll error:`, error);
+      Log.debug(`[MT - ${getTimestamp()}] Manifest poll error:`, error);
     } finally {
       this.isFetchingManifest = false;
     }
@@ -747,7 +782,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
   mergeNewAds(newAds) {
     this.adSchedule = mergeAdSchedules(this.adSchedule, newAds);
 
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Ad schedule: ${this.adSchedule.length} ad break(s)`,
     );
 
@@ -758,7 +793,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       !this.hasAttemptedTrackingFetch
     ) {
       this.hasAttemptedTrackingFetch = true;
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Fetching tracking metadata (first manifest parse)`,
       );
       this.getAndProcessTrackingMetadata();
@@ -782,7 +817,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     }
 
     this.liveRefreshIntervalSeconds = intervalSeconds;
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Derived live polling interval from ${source}: ${intervalSeconds}s`,
     );
 
@@ -798,7 +833,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     if (this.isDisposed || !this.trackingEndpointUrl) return;
 
     if (this.isFetchingTracking) {
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Tracking fetch already in progress, skipping`,
       );
       return;
@@ -807,7 +842,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     this.isFetchingTracking = true;
 
     try {
-      console.log(`[MT - ${getTimestamp()}] Fetching tracking metadata`);
+      Log.debug(`[MT - ${getTimestamp()}] Fetching tracking metadata`);
 
       this.trackingAbortController = new AbortController();
 
@@ -818,35 +853,35 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       );
 
       if (this.isDisposed) {
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Disposed during tracking fetch, ignoring result`,
         );
         return;
       }
 
       if (data.avails && data.avails.length > 0) {
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Enriching with ${data.avails.length} avail(s)`,
         );
         this.enrichWithTrackingMetadata(data.avails);
         this.trackingFetchRetries = 0;
       } else {
-        console.log(`[MT - ${getTimestamp()}] Tracking API returned 0 avails`);
+        Log.debug(`[MT - ${getTimestamp()}] Tracking API returned 0 avails`);
       }
     } catch (error) {
       if (error.name === 'AbortError' || this.isDisposed) {
-        console.log(`[MT - ${getTimestamp()}] Tracking fetch aborted`);
+        Log.debug(`[MT - ${getTimestamp()}] Tracking fetch aborted`);
         return;
       }
 
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Tracking API error: ${error.message}`,
         error,
       );
 
       if (this.trackingFetchRetries < this.maxTrackingRetries) {
         this.trackingFetchRetries++;
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Retrying tracking fetch (${this.trackingFetchRetries}/${this.maxTrackingRetries})`,
         );
         this.isFetchingTracking = false;
@@ -854,7 +889,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
         return;
       }
 
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] Max retries reached, continuing with manifest data only`,
       );
     } finally {
@@ -875,14 +910,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       this.adSchedule.sort((a, b) => a.startTime - b.startTime);
     }
 
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Enrichment complete: ${
         this.adSchedule.length
       } ad break(s)`,
     );
 
     // Log enriched schedule with full details
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Enriched schedule:`,
       this.adSchedule.map((ab) => ({
         id: ab.id,
@@ -901,7 +936,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     );
 
     // Log current player time for debugging
-    console.log(
+    Log.debug(
       `[MT - ${getTimestamp()}] Current player time: ${this.player.currentTime()}s`,
     );
   }
@@ -919,7 +954,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
     });
 
     quartilesToFire.forEach(({ quartile, key }) => {
-      console.log(`[MT - ${getTimestamp()}] → AD_QUARTILE ${quartile * 25}%`);
+      Log.debug(`[MT - ${getTimestamp()}] → AD_QUARTILE ${quartile * 25}%`);
       this.sendAdQuartile({ quartile });
       adObject[`hasFired${key.toUpperCase()}`] = true;
     });
@@ -938,7 +973,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       Math.floor(currentTime) % 5 === 0 &&
       Math.floor(currentTime * 10) % 10 === 0
     ) {
-      console.log(
+      Log.debug(
         `[MT - ${getTimestamp()}] TimeUpdate: ${currentTime.toFixed(2)}s, Active break: ${
           activeAdBreak ? activeAdBreak.id : 'none'
         }, Schedule count: ${this.adSchedule.length}`,
@@ -952,7 +987,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       if (!activeAdBreak.hasFiredStart) {
         this.currentAdBreak = activeAdBreak;
         this.setIsAd(true); // Switch to ad mode
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] setIsAd(true) - Entering ad break`,
         );
 
@@ -969,7 +1004,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
         // Store position on the ad break for reuse
         activeAdBreak.adPosition = adPosition;
 
-        console.log(`[MT - ${getTimestamp()}] → AD_BREAK_START`, {
+        Log.debug(`[MT - ${getTimestamp()}] → AD_BREAK_START`, {
           startTime: activeAdBreak.startTime,
           duration: activeAdBreak.duration,
           podCount: activeAdBreak.pods?.length || 0,
@@ -990,14 +1025,14 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
           if (!this.currentAdPod || this.currentAdPod !== activePod) {
             // End previous pod
             if (this.currentAdPod) {
-              console.log(`[MT - ${getTimestamp()}] → AD_END (pod transition)`);
+              Log.debug(`[MT - ${getTimestamp()}] → AD_END (pod transition)`);
               this.sendEnd();
             }
 
             // Start new pod
             this.currentAdPod = activePod;
 
-            console.log(`[MT - ${getTimestamp()}] → AD_START (new pod)`, {
+            Log.debug(`[MT - ${getTimestamp()}] → AD_START (new pod)`, {
               startTime: activePod.startTime,
               duration: activePod.duration,
               position: activeAdBreak.adPosition,
@@ -1030,7 +1065,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       } else {
         // No pods - treat entire break as single ad
         if (!activeAdBreak.hasFiredAdStart) {
-          console.log(`[MT - ${getTimestamp()}] → AD_START (no pods)`, {
+          Log.debug(`[MT - ${getTimestamp()}] → AD_START (no pods)`, {
             startTime: activeAdBreak.startTime,
             duration: activeAdBreak.duration,
             position: activeAdBreak.adPosition,
@@ -1059,25 +1094,25 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
 
       // End last pod
       if (this.currentAdPod) {
-        console.log(`[MT - ${getTimestamp()}] → AD_END (final pod)`);
+        Log.debug(`[MT - ${getTimestamp()}] → AD_END (final pod)`);
         this.sendEnd();
         this.currentAdPod = null;
       }
 
       // End ad break
       if (!this.currentAdBreak.hasFiredEnd) {
-        console.log(`[MT - ${getTimestamp()}] → AD_BREAK_END`);
+        Log.debug(`[MT - ${getTimestamp()}] → AD_BREAK_END`);
         this.sendAdBreakEnd();
         this.currentAdBreak.hasFiredEnd = true;
       }
 
       this.currentAdBreak = null;
       this.setIsAd(false); // Switch back to content mode
-      console.log(`[MT - ${getTimestamp()}] setIsAd(false) - Exiting ad break`);
+      Log.debug(`[MT - ${getTimestamp()}] setIsAd(false) - Exiting ad break`);
 
       // Check if video has ended after exiting last ad break
       if (this.player.ended() && !this.hasEndedContent) {
-        console.log(
+        Log.debug(
           `[MT - ${getTimestamp()}] Video ended after last ad → CONTENT_END`,
         );
         this.sendContentEnd();
@@ -1104,7 +1139,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    */
   handleAdEvent(eventName, sendMethod) {
     if (this.isAd()) {
-      console.log(`[MT - ${getTimestamp()}] → ${eventName}`);
+      Log.debug(`[MT - ${getTimestamp()}] → ${eventName}`);
       sendMethod.call(this);
     }
   }
@@ -1121,7 +1156,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    */
   onPlaying() {
     if (this.isAd()) {
-      console.log(`[MT - ${getTimestamp()}] → AD_RESUME`);
+      Log.debug(`[MT - ${getTimestamp()}] → AD_RESUME`);
       this.sendResume();
       this.sendBufferEnd(); // Playing event also ends any buffering
     }
@@ -1153,7 +1188,7 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
    */
   onEnded() {
     if (!this.hasEndedContent) {
-      console.log(`[MT - ${getTimestamp()}] Video ended → CONTENT_END`);
+      Log.debug(`[MT - ${getTimestamp()}] Video ended → CONTENT_END`);
       this.sendContentEnd();
       this.hasEndedContent = true;
     }
@@ -1216,25 +1251,25 @@ export default class MediaTailorAdsTracker extends VideojsAdsTracker {
       this.trackingPollTimer = null;
     }
 
-    console.log(`[MT - ${getTimestamp()}] Polling stopped`);
+    Log.debug(`[MT - ${getTimestamp()}] Polling stopped`);
   }
 
   /**
    * Cleanup when tracker is destroyed
    */
   dispose() {
-    console.log(`[MT - ${getTimestamp()}] Disposing MediaTailorAdsTracker`);
+    Log.debug(`[MT - ${getTimestamp()}] Disposing MediaTailorAdsTracker`);
 
     this.isDisposed = true;
 
     if (this.trackingAbortController) {
-      console.log(`[MT - ${getTimestamp()}] Aborting in-flight tracking fetch`);
+      Log.debug(`[MT - ${getTimestamp()}] Aborting in-flight tracking fetch`);
       this.trackingAbortController.abort();
       this.trackingAbortController = null;
     }
 
     if (this.manifestAbortController) {
-      console.log(`[MT - ${getTimestamp()}] Aborting in-flight manifest fetch`);
+      Log.debug(`[MT - ${getTimestamp()}] Aborting in-flight manifest fetch`);
       this.manifestAbortController.abort();
       this.manifestAbortController = null;
     }

--- a/src/ads/utils/mt-constants.js
+++ b/src/ads/utils/mt-constants.js
@@ -36,7 +36,8 @@ export const DASH_SCTE35_EVENT_STREAM_SELECTOR =
 export const HLS_MIME_TYPE = 'application/vnd.apple.mpegurl'; // MIME type used to detect Safari/native HLS playback support
 
 // MediaTailor URL Patterns
-export const MT_SEGMENT_PATTERN = 'segments.mediatailor'; // Identifies MediaTailor ad segments
+export const MT_SEGMENT_PATTERN = 'segments.mediatailor'; // Identifies MediaTailor ad segments (AWS default hostname)
+export const MT_DEFAULT_AD_SEGMENT_PATH = '/tm/'; // Default ad-segment path per AWS CDN integration guide (custom-CDN setups)
 
 export const TRACKING_API_TIMEOUT_MS = 5000; // Keep tracking metadata requests within the guide's 5s end-to-end budget
 export const DEFAULT_LIVE_POLL_INTERVAL_MS = 5000; // Temporary fallback until manifest metadata provides cadence

--- a/src/ads/utils/mt.js
+++ b/src/ads/utils/mt.js
@@ -3,6 +3,11 @@
  * Helper functions for AWS MediaTailor ad tracking
  */
 
+import nrvideo from '@newrelic/video-core';
+
+const nrvideoCore = nrvideo.default || nrvideo;
+const Log = nrvideoCore.Log;
+
 import {
   DASH_MANIFEST_EXTENSION,
   DASH_SCTE35_EVENT_STREAM_SELECTOR,
@@ -21,6 +26,7 @@ import {
   MT_HLS_CUE_IN_TAG,
   MT_HLS_CUE_OUT_TAG,
   MT_SEGMENT_PATTERN,
+  MT_DEFAULT_AD_SEGMENT_PATH,
   MIN_AD_DURATION,
   AD_TIMING_TOLERANCE,
   SCTE35_SCHEME_MARKER,
@@ -84,16 +90,30 @@ export function buildTrackingEndpointUrl(manifestUrl) {
 /**
  * Checks if segment is a MediaTailor ad segment
  */
-export function isMediaTailorSegment(segment) {
-  // Check MAP URL for MediaTailor pattern
-  if (segment.map && segment.map.uri && segment.map.uri.includes(MT_SEGMENT_PATTERN)) {
-    return true;
-  }
-  // Check segment URL for MediaTailor pattern
-  if (segment.uri && segment.uri.includes(MT_SEGMENT_PATTERN)) {
-    return true;
-  }
-  return false;
+export function isMediaTailorSegment(segment, { adSegmentPrefix } = {}) {
+  const candidates = [MT_SEGMENT_PATTERN, MT_DEFAULT_AD_SEGMENT_PATH];
+  if (adSegmentPrefix) candidates.push(adSegmentPrefix);
+
+  const mapUri = (segment.map && segment.map.uri) || '';
+  const segUri = segment.uri || '';
+
+  return candidates.some(
+    (marker) => mapUri.includes(marker) || segUri.includes(marker),
+  );
+}
+
+export function whichAdSegmentMarker(segment, { adSegmentPrefix } = {}) {
+  const labeled = [
+    { marker: MT_SEGMENT_PATTERN,        label: 'aws-hostname (segments.mediatailor)' },
+    { marker: MT_DEFAULT_AD_SEGMENT_PATH, label: 'default-cdn-path (/tm/)' },
+  ];
+  if (adSegmentPrefix) labeled.push({ marker: adSegmentPrefix, label: `custom-prefix (${adSegmentPrefix})` });
+
+  const mapUri = (segment.map && segment.map.uri) || '';
+  const segUri = segment.uri || '';
+
+  const hit = labeled.find(({ marker }) => mapUri.includes(marker) || segUri.includes(marker));
+  return hit ? hit.label : null;
 }
 
 /**
@@ -350,7 +370,7 @@ export function parseHlsManifestForAdBreaks(manifestText) {
 /**
  * Detects ads from VHS playlist using discontinuityStarts and MediaTailor segments
  */
-export function detectAdBreaksFromVhsPlaylist(playlist) {
+export function detectAdBreaksFromVhsPlaylist(playlist, { adSegmentPrefix } = {}) {
   const segments = playlist.segments;
   const discontinuityStarts = playlist.discontinuityStarts || [];
   const adBreaks = [];
@@ -360,7 +380,7 @@ export function detectAdBreaksFromVhsPlaylist(playlist) {
   let currentTime = 0;
 
   segments.forEach((segment, index) => {
-    const isMTSegment = isMediaTailorSegment(segment);
+    const isMTSegment = isMediaTailorSegment(segment, { adSegmentPrefix });
     const hasDiscontinuity = discontinuityStarts.includes(index);
 
     if (isMTSegment) {
@@ -627,19 +647,19 @@ export function parseIsoDuration(durationStr) {
  * SINGLE_PERIOD: the entire stream is one period; ads are signalled via
  * SCTE-35 <EventStream> elements inside that period.
  */
-export function parseDashManifestForAdBreaks(xmlText) {
+export function parseDashManifestForAdBreaks(xmlText, { adSegmentPrefix } = {}) {
   const parser = new DOMParser();
   const xml = parser.parseFromString(xmlText, 'text/xml');
   const ads = [];
 
   const parserError = xml.querySelector('parsererror');
   if (parserError) {
-    console.error('[MT] DASH XML parse error:', parserError.textContent);
+    Log.error('[MT] DASH XML parse error:', parserError.textContent);
     return ads;
   }
 
   const periods = xml.querySelectorAll('Period');
-  console.log(`[MT] Found ${periods.length} Period(s) in DASH manifest`);
+  Log.debug(`[MT] Found ${periods.length} Period(s) in DASH manifest`);
 
   if (periods.length > 1) {
     // ── MULTI_PERIOD ──────────────────────────────────────────────────────────
@@ -648,7 +668,9 @@ export function parseDashManifestForAdBreaks(xmlText) {
       const baseUrlEl = period.querySelector('BaseURL');
       const baseUrl = baseUrlEl ? baseUrlEl.textContent.trim() : '';
 
-      if (!baseUrl.includes(MT_SEGMENT_PATTERN)) {
+      const adCandidates = [MT_SEGMENT_PATTERN, MT_DEFAULT_AD_SEGMENT_PATH];
+      if (adSegmentPrefix) adCandidates.push(adSegmentPrefix);
+      if (!adCandidates.some((m) => baseUrl.includes(m))) {
         return; // content period
       }
 
@@ -657,11 +679,11 @@ export function parseDashManifestForAdBreaks(xmlText) {
       const duration = parseIsoDuration(period.getAttribute('duration') || '');
 
       if (duration < MIN_AD_DURATION) {
-        console.log(`[MT] Skipping period ${periodId} - duration too short (${duration}s)`);
+        Log.debug(`[MT] Skipping period ${periodId} - duration too short (${duration}s)`);
         return;
       }
 
-      console.log(`[MT] Ad period detected: ${periodId}`, { startTime, duration });
+      Log.debug(`[MT] Ad period detected: ${periodId}`, { startTime, duration });
 
       ads.push({
         id: periodId,
@@ -686,7 +708,7 @@ export function parseDashManifestForAdBreaks(xmlText) {
       DASH_SCTE35_EVENT_STREAM_SELECTOR,
     );
 
-    console.log(`[MT] Found ${eventStreams.length} SCTE-35 EventStream(s) in single-period manifest`);
+    Log.debug(`[MT] Found ${eventStreams.length} SCTE-35 EventStream(s) in single-period manifest`);
 
     eventStreams.forEach((stream) => {
       const timescale = parseFloat(stream.getAttribute('timescale') || '1');
@@ -702,11 +724,11 @@ export function parseDashManifestForAdBreaks(xmlText) {
         const durationSeconds = timescale !== 1 ? duration / timescale : duration;
 
         if (durationSeconds < MIN_AD_DURATION) {
-          console.log(`[MT] Skipping event ${eventId} - duration too short (${durationSeconds}s)`);
+          Log.debug(`[MT] Skipping event ${eventId} - duration too short (${durationSeconds}s)`);
           return;
         }
 
-        console.log(`[MT] SCTE-35 event detected: ${eventId}`, { startTime, durationSeconds });
+        Log.debug(`[MT] SCTE-35 event detected: ${eventId}`, { startTime, durationSeconds });
 
         ads.push({
           id: eventId,
@@ -727,7 +749,7 @@ export function parseDashManifestForAdBreaks(xmlText) {
     });
   }
 
-  console.log(`[MT] Parsed ${ads.length} valid ad break(s) from DASH manifest`);
+  Log.debug(`[MT] Parsed ${ads.length} valid ad break(s) from DASH manifest`);
   return ads;
 }
 

--- a/src/register-plugin.js
+++ b/src/register-plugin.js
@@ -12,8 +12,8 @@ if (typeof videojs !== 'undefined') {
    */
   registerPlugin('newrelic', function (options) {
     if (!this.newrelictracker) {
-      this.newrelictracker = new nrvideo.VideojsTracker(this);
-      nrvideo.Core.addTracker(this.newrelictracker);
+      this.newrelictracker = new nrvideo.VideojsTracker(this, options);
+      nrvideo.Core.addTracker(this.newrelictracker, options);
     }
     return this.newrelictracker;
   });

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -194,7 +194,8 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
       if (tech?.vhs?.playlists?.media()) {
         const activePlaylist = tech.vhs.playlists.media();
         // Use AVERAGE-BANDWIDTH if available, fallback to BANDWIDTH
-        const bitrate = activePlaylist.attributes['AVERAGE-BANDWIDTH'] ||
+        const bitrate =
+          activePlaylist.attributes['AVERAGE-BANDWIDTH'] ||
           activePlaylist.attributes.BANDWIDTH ||
           null;
         return bitrate !== null ? Math.round(bitrate) : null;
@@ -344,6 +345,7 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
     this.onTimeupdate = this.onTimeupdate.bind(this);
     this.OnAdsAllpodsCompleted = this.OnAdsAllpodsCompleted.bind(this);
     this.onStreamManager = this.onStreamManager.bind(this);
+    this.onCanPlayThrough = this.onCanPlayThrough.bind(this);
 
     this.player.on('loadstart', this.onDownload);
     this.player.on('loadeddata', this.onDownload);
@@ -364,6 +366,7 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
     this.player.on('timeupdate', this.onTimeupdate);
     this.player.on('ads-allpods-completed', this.OnAdsAllpodsCompleted);
     this.player.on('stream-manager', this.onStreamManager);
+    this.player.on('canplaythrough', this.onCanPlayThrough);
   }
 
   unregisterListeners() {
@@ -386,6 +389,7 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
     this.player.off('timeupdate', this.onTimeupdate);
     this.player.off('ads-allpods-completed', this.OnAdsAllpodsCompleted);
     this.player.off('stream-manager', this.onStreamManager);
+    this.player.off('canplaythrough', this.onCanPlayThrough);
   }
 
   onDownload(e) {
@@ -470,6 +474,11 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
    * @returns {boolean} True if ads are playing
    */
   isAdsTrackerActive() {
+    // For CSAI: videojs-contrib-ads manages ad state exclusively
+    if (this.player.ads) {
+      return this.player.ads.state === 'ads-playback';
+    }
+    // For SSAI (no player.ads): check tracker's isAd flag (manually toggled)
     return this.adsTracker && this.adsTracker.isAd && this.adsTracker.isAd();
   }
 
@@ -487,6 +496,16 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
       return;
     }
     this.sendPause();
+  }
+
+  onCanPlayThrough() {
+    // Don't send CONTENT_BUFFER_END if ads are playing (ads tracker handles it)
+    if (this.isAdsTrackerActive()) {
+      return;
+    }
+    // Send BUFFER_END when buffer fills, even if paused
+    // This ensures accurate buffer duration metrics when user pauses during buffering
+    this.sendBufferEnd();
   }
 
   onPlaying() {

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -10,6 +10,30 @@ import FreewheelAdsTracker from './ads/freewheel';
 import DaiAdsTracker from './ads/dai';
 import MediaTailorAdsTracker from './ads/media-tailor';
 
+/**
+ * Explicit ad tracking modes. Pass via config.ad.type.
+ *
+ * CSAI (Client-Side Ad Insertion)
+ *   All CSAI frameworks share the adsready event path. The tracker auto-detects
+ *   the right framework (Brightcove IMA → IMA → Freewheel → generic) — no sub-type needed.
+ *
+ * SSAI (Server-Side Ad Insertion) — sub-type is always required.
+ *   Each SSAI platform has its own SDK and a different activation path.
+ *   Cannot be auto-detected — declare which one you are using.
+ *   SSAI.DAI — Google DAI (google.ima.dai.api)
+ *   SSAI.MT  — AWS MediaTailor
+ *
+ * If config.ad is not set, no ad tracking runs (safe default).
+ * To add a new SSAI platform: add a key to SSAI — validation derives from this object.
+ */
+export const AD_TRACKING = {
+  CSAI: 'csai',
+  SSAI: Object.freeze({
+    DAI: 'ssai:dai',
+    MT:  'ssai:mt',
+  }),
+};
+
 export default class VideojsTracker extends nrvideo.VideoTracker {
   constructor(player, options) {
     super(player, options);
@@ -17,7 +41,51 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
     this.isContentEnd = false;
     this.imaAdCuePoints = '';
     this.daiInitialized = false;
+    this.adTracking = options?.config?.ad?.type || null;
+
+    // When options are provided but config.ad is not declared, no ad tracking
+    // will run. Warn so the caller knows to set it explicitly.
+    if (options && !this.adTracking) {
+      nrvideo.Log.warn(
+        'VideojsTracker: config.ad not set — no ad tracking will run. ' +
+        'Set config.ad.type to enable it (e.g. AD_TRACKING.CSAI, AD_TRACKING.SSAI.MT).'
+      );
+    }
+
+    // Merge config.ad options (segmentPrefix, trackingUrl) into the internal
+    // mediatailor object that MediaTailorAdsTracker reads.
+    if (this.adTracking === AD_TRACKING.SSAI.MT) {
+      const adConfig = options?.config?.ad || {};
+      this.options = Object.assign({}, this.options, {
+        mediatailor: {
+          segmentPrefix: adConfig.segmentPrefix,
+          trackingUrl:   adConfig.trackingUrl,
+          ...this.options?.mediatailor,
+        },
+      });
+    }
+
     nrvideo.Core.addTracker(this, options);
+  }
+
+  /**
+   * Sets the ad tracking mode at runtime.
+   * Must be called before the first loadstart / adsready event to take effect.
+   * @param {'csai'|'ssai:dai'|'ssai:mt'} type
+   */
+  setAdTracking(type) {
+    const valid = [
+      AD_TRACKING.CSAI,
+      ...Object.values(AD_TRACKING.SSAI),
+    ];
+    if (!valid.includes(type)) {
+      nrvideo.Log.warn(
+        `VideojsTracker.setAdTracking: unknown value "${type}". Valid values: ${valid.join(', ')}`
+      );
+      return;
+    }
+    this.adTracking = type;
+    nrvideo.Log.debug(`VideojsTracker: adTracking set to "${type}"`);
   }
 
   getTech() {
@@ -323,25 +391,25 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   onDownload(e) {
     this.sendDownload({ state: e.type });
 
-    // Check if MediaTailor should be used after the source is loaded
-    // Only check on 'loadstart' to avoid multiple checks
     if (
+      this.adTracking === AD_TRACKING.SSAI.MT &&
       !this.adsTracker &&
-      e.type === 'loadstart' &&
-      MediaTailorAdsTracker.isUsing(this.player)
+      e.type === 'loadstart'
     ) {
-      console.log(
-        'VideojsTracker: Creating MediaTailorAdsTracker after source load'
-      );
+      nrvideo.Log.debug('VideojsTracker: Creating MediaTailorAdsTracker');
       this.setAdsTracker(new MediaTailorAdsTracker(this.player, this.options));
-      // MediaTailor SSAI starts with content, not ads (unlike client-side ad frameworks)
+      // MediaTailor SSAI starts with content, not ads (unlike client-side frameworks)
       this.adsTracker.setIsAd(false);
     }
   }
 
   // DAI methods
   onStreamManager(event) {
-    if (!this.adsTracker && event.StreamManager) {
+    if (
+      this.adTracking === AD_TRACKING.SSAI.DAI &&
+      !this.adsTracker &&
+      event.StreamManager
+    ) {
       const daiTracker = new DaiAdsTracker(this.player);
       daiTracker.setStreamManager(event.StreamManager);
       this.setAdsTracker(daiTracker);
@@ -350,20 +418,29 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   // DAI methods end
 
   onAdsready() {
+    // SSAI platforms never fire adsready — skip when an SSAI type is explicitly set.
+    if (Object.values(AD_TRACKING.SSAI).includes(this.adTracking)) return;
+
+    // config.ad.type is not set — warn and fall back to auto-detection.
+    if (!this.adTracking) {
+      nrvideo.Log.warn(
+        'VideojsTracker: adsready fired but config.ad.type is not set — ' +
+        'attempting CSAI auto-detection for backward compatibility.'
+      );
+    }
+
     if (!this.adsTracker) {
       if (BrightcoveImaAdsTracker.isUsing(this.player)) {
-        // BC IMA
+        nrvideo.Log.debug('VideojsTracker: auto-detected BrightcoveImaAdsTracker');
         this.setAdsTracker(new BrightcoveImaAdsTracker(this.player));
       } else if (ImaAdsTracker.isUsing(this.player)) {
-        // IMA
+        nrvideo.Log.debug('VideojsTracker: auto-detected ImaAdsTracker');
         this.setAdsTracker(new ImaAdsTracker(this.player));
       } else if (FreewheelAdsTracker.isUsing(this.player)) {
-        // FW
-
+        nrvideo.Log.debug('VideojsTracker: auto-detected FreewheelAdsTracker');
         this.setAdsTracker(new FreewheelAdsTracker(this.player));
-        // } else if (OnceAdsTracker.isUsing(this)) { // Once
       } else {
-        // Generic
+        nrvideo.Log.debug('VideojsTracker: no specific CSAI framework detected, using generic VideojsAdsTracker');
         this.setAdsTracker(new VideojsAdsTracker(this.player));
       }
     }
@@ -481,6 +558,11 @@ export default class VideojsTracker extends nrvideo.VideoTracker {
   }
 }
 
+// Attach AD_TRACKING and Log as static properties so UMD callers can use
+// VideojsTracker.AD_TRACKING and VideojsTracker.Log without importing named exports.
+VideojsTracker.AD_TRACKING = AD_TRACKING;
+VideojsTracker.Log = nrvideo.Log;
+
 // Static members
 export {
   HlsJsTech,
@@ -490,5 +572,6 @@ export {
   ImaAdsTracker,
   BrightcoveImaAdsTracker,
   FreewheelAdsTracker,
+  DaiAdsTracker,
   MediaTailorAdsTracker,
 };


### PR DESCRIPTION
…config

* feat: support custom CDN / custom domain for MediaTailor SSAI

Previously the MediaTailor tracker auto-activated by substring-matching '.mediatailor.' in the player's current source URL. This silently broke for any customer who placed a CDN in front of MediaTailor with a custom hostname — the tracker was never instantiated and no ad events reached New Relic.

Changes:
- Replace URL-based auto-detection with an explicit opt-in flag. Customers pass `mediatailor: true` (or `mediatailor: { trackingUrl, adSegmentPrefix }` for advanced setups) when initialising the tracker. The flag is now required for both default AWS hostnames and custom CDN domains.

- Add MT_DEFAULT_AD_SEGMENT_PATH ('/tm/') constant — the AWS-recommended CDN ad-segment path prefix per the CDN integration guide. Ad segments rewritten to a custom CDN domain under /tm/ are detected automatically without any extra configuration.

- Update isMediaTailorSegment() to check three candidates: the default AWS segments hostname, the /tm/ path, and an optional customer-supplied adSegmentPrefix override.

- Thread adSegmentPrefix through detectAdBreaksFromVhsPlaylist() and parseDashManifestForAdBreaks() so custom prefix detection works for both HLS (VHS) and DASH streams.

- Support explicit session initialisation: when the customer uses a POST /v1/session/ flow, they can pass `mediatailor: { trackingUrl }` to supply the tracking URL directly, bypassing the ?aws.sessionId= derivation that only works for implicit sessions.

- Update samples/media-tailor-lab.html: add mediatailor: true to tracker options, add Initialize Session button for POST-based sessions (handles relative manifest/tracking URLs), and auto-play after session init.

- Add test/ads/media-tailor.custom-cdn.test.js covering: opt-in flag, removal of auto-detect, /tm/ default detection, custom prefix override, and trackingUrl explicit override.

API:
  // Simple — default AWS hostname or custom CDN with /tm/ ad segments videojsTracker(player, { mediatailor: true });

  // Advanced — explicit session or non-/tm/ ad segment prefix videojsTracker(player, { mediatailor: { trackingUrl, adSegmentPrefix } });

Tested end-to-end with a real MediaTailor stream behind a Cloudflare tunnel simulating a custom CDN domain (no .mediatailor. in any URL).

* chore: remove test file — no test infrastructure in this repo

* fix: remove hardcoded MediaTailor endpoint from sample app

* docs: clarify when trackingUrl and adSegmentPrefix overrides are needed

* docs: update ssai.md and README for custom CDN support, clean up sessionId references

* refactor: replace console.log/warn/error with nrvideo.Log in MediaTailor files

* feat: add adTracking option to control ad tracker selection

Exposes AD_TRACKING constant ('automatic' | 'none' | 'ima' | 'mt') and a setAdTracking() method so callers can opt in to a specific ad framework rather than relying entirely on auto-detection.

- 'none' disables all ad tracker creation
- 'ima' restricts to IMA / Brightcove IMA only
- 'mt' restricts to MediaTailor only and implies mediatailor:true
- 'automatic' preserves existing auto-detect behaviour (default)

Also fixes register-plugin.js which was silently dropping the options object and never forwarding it to the TrackerJS constructor.

* feat: warn when adTracking not set explicitly, document explicit-first pattern

* feat: restructure AD_TRACKING into CSAI/SSAI groups with sub-type enforcement

CSAI (Client-Side) groups IMA, Brightcove IMA, and Freewheel — all share the adsready path so CSAI.ALL can auto-detect the best match.

SSAI (Server-Side) requires explicit sub-type (DAI or MT) — each platform needs its own SDK and cannot be auto-detected. No SSAI.ALL.

adTracking not set = no ad tracking (safe default, warns if options passed). SSAI.MT still implies mediatailor:true. DaiAdsTracker added to static exports.

* feat: simplify AD_TRACKING — CSAI is a flat value, no sub-types needed

All CSAI frameworks (IMA, Brightcove IMA, Freewheel, generic) share the adsready path and are auto-detected. No sub-type is needed — AD_TRACKING.CSAI covers all of them. onAdsready reduces to a single equality check.

SSAI sub-types (DAI, MT) are still required — each platform needs its own SDK and cannot be auto-detected.

* refactor: move ad config to config.ad.type per RFC

Replace top-level adTracking option with config.ad.type, co-locate segmentPrefix and trackingUrl inside config.ad, update warning messages. No backward compat shims — adTracking and mediatailor were never customer-facing in v4.1.2.

* feat: expose Log on tracker, add ad segment detection path logging

- Attach VideojsTracker.Log as static so UMD callers can set log level
- Log active ad segment detection mode at tracker startup (constructor)
- Add whichAdSegmentMarker helper to identify which candidate matched
- Log matched detection path on first ad break found (once per session)
- Install commitlint dev dependencies

* feat: rewrite media-tailor-lab sample app

- Clean minimal UI: license key, app ID, playback URL, format toggle
- Smart Load button handles both session init and direct playback URLs
- NR log level toggle (Error/Warning/Debug/All) controls tracker verbosity
- Debug log shows detected mode (AWS default vs custom CDN) before load
- Credentials and URL persisted in localStorage

* chore: remove commitlint from package.json (was added by mistake)

* docs: fix adSegmentPrefix → config.ad.segmentPrefix in ssai.md troubleshooting

* fix: relax adsready guard, add CSAI auto-detection logs

- Only block adsready when adTracking is explicitly set to an SSAI type
- If config.ad.type is not set, fall back to CSAI auto-detection with a warning (backward compat for users upgrading from v4.1.2)
- Log which CSAI framework was auto-detected (BrightcoveIma / IMA / Freewheel / generic) at debug level

* fix: simplify adsready guard to check explicit SSAI values only

Replace ambiguous double-condition with Object.values(AD_TRACKING.SSAI).includes() so intent is clear: skip only when adTracking is an explicit SSAI type, never when it is CSAI or unset.

-------