### PR TITLE
chore(release): prep 4.2.0 and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,9 @@ name: Release
 # create git tags, and publish GitHub releases.
 
 on:
-  pull_request:
+  push:
     branches:
       - master
-    types:
-      - closed
   workflow_dispatch:
     inputs:
       dry-run:
@@ -32,14 +30,16 @@ jobs:
     outputs:
       new-release-published: ${{ steps.semantic.outputs.new-release-published }}
       new-release-version: ${{ steps.semantic.outputs.new-release-version }}
-    # Only run when PR is merged or workflow is manually triggered
+    # Run on push to master or manual dispatch. Skip the bot's own release
+    # commit so we don't recurse on `chore(release): … [skip ci]`.
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.merged == true
+      (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]'))
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
+          ref: master
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -80,16 +80,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release > semantic-output.log 2>&1 || true
-          cat semantic-output.log
+          # Capture the tag at HEAD before semantic-release runs so we can
+          # detect a new tag deterministically (no log-grepping).
+          PREV_TAG=$(git tag --points-at HEAD | head -n1 || true)
 
-          # Check if release was published
-          if grep -q "Published release" semantic-output.log || grep -q "Release published" semantic-output.log; then
-            echo "new-release-published=true" >> $GITHUB_OUTPUT
-            # Extract version from package.json after semantic-release
+          # Fail loudly on real errors instead of swallowing them with `|| true`.
+          npx semantic-release | tee semantic-output.log
+
+          NEW_TAG=$(git tag --points-at HEAD | head -n1 || true)
+          if [ -n "$NEW_TAG" ] && [ "$NEW_TAG" != "$PREV_TAG" ]; then
             NEW_VERSION=$(jq -r '.version' package.json)
+            echo "new-release-published=true" >> $GITHUB_OUTPUT
             echo "new-release-version=$NEW_VERSION" >> $GITHUB_OUTPUT
-            echo "Release published: v$NEW_VERSION"
+            echo "Release published: $NEW_TAG"
           else
             echo "new-release-published=false" >> $GITHUB_OUTPUT
             echo "No release published"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [4.2.0](https://github.com/newrelic/video-videojs-js/compare/v4.1.1...v4.2.0) (2026-05-11)
+## [4.1.2](https://github.com/newrelic/video-videojs-js/compare/v4.1.1...v4.1.2) (2026-05-11)
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/video-videojs",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "New relic tracker for Videojs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
- Bump package.json to 4.2.0
- Fix CHANGELOG.md: previous [4.2.0] header was mislabeled and is actually [4.1.2]
- Switch release workflow trigger from pull_request:closed to push:master so semantic-release runs after merge
- Pin checkout to master, guard recursion via [skip ci], detect new release via git tag instead of log-grepping